### PR TITLE
[Feat][PO-50] HomeKit 조명 제어 연동

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5EA4DF22F1DFC6B004FF6C7"
+               BuildableName = "LivingStory-iOS.app"
+               BlueprintName = "LivingStory-iOS"
+               ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5EA4E0B2F1DFC6C004FF6C7"
+               BuildableName = "LivingStory-iOSTests.xctest"
+               BlueprintName = "LivingStory-iOSTests"
+               ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5EA4E152F1DFC6C004FF6C7"
+               BuildableName = "LivingStory-iOSUITests.xctest"
+               BlueprintName = "LivingStory-iOSUITests"
+               ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5EA4DF22F1DFC6B004FF6C7"
+            BuildableName = "LivingStory-iOS.app"
+            BlueprintName = "LivingStory-iOS"
+            ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5EA4DF22F1DFC6B004FF6C7"
+            BuildableName = "LivingStory-iOS.app"
+            BlueprintName = "LivingStory-iOS"
+            ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -101,7 +101,17 @@ final class AppCoordinator: Coordinator {
 
     /// 독서 중 화면 (SwiftUI)
     func showReading(book: BookProfileModel) {
-        let viewModel = ReadingViewModel(book: book)
+        let lightingController: any LightingControllable
+        #if DEBUG
+        lightingController = MockLightingController()
+        #else
+        lightingController = HomeKitLightingController()
+        #endif
+
+        let viewModel = ReadingViewModel(
+            book: book,
+            lightingController: lightingController
+        )
         let view = ReadingView(coordinator: self, viewModel: viewModel)
         let hostingVC = UIHostingController(rootView: view)
         (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -137,6 +137,7 @@ struct ReadingView: View {
     }
 }
 
+#if DEBUG
 #Preview("독서 중") {
     NavigationView {
         ReadingView(
@@ -149,3 +150,4 @@ struct ReadingView: View {
         )
     }
 }
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -26,6 +26,7 @@ final class ReadingViewModel {
     private let audioPlayerService: AudioPlayerService
     private let bookRepository: BookRepositoryProtocol
     private let sessionRepository: ReadingSessionRepositoryProtocol
+    private let lightingController: (any LightingControllable)?
     private var timerTask: Task<Void, Never>?
     private var startTime: Date?
     private var hasStarted = false
@@ -35,13 +36,15 @@ final class ReadingViewModel {
         geminiService: GeminiService? = nil,
         audioPlayerService: AudioPlayerService? = nil,
         bookRepository: BookRepositoryProtocol? = nil,
-        sessionRepository: ReadingSessionRepositoryProtocol? = nil
+        sessionRepository: ReadingSessionRepositoryProtocol? = nil,
+        lightingController: (any LightingControllable)? = nil
     ) {
         self.book = book
         self.geminiService = geminiService ?? GeminiService()
         self.audioPlayerService = audioPlayerService ?? AudioPlayerService()
         self.bookRepository = bookRepository ?? BookRepository()
         self.sessionRepository = sessionRepository ?? ReadingSessionRepository()
+        self.lightingController = lightingController
     }
 
     // MARK: - Public
@@ -69,8 +72,16 @@ final class ReadingViewModel {
             print("[Gemini] 조명: H\(environment.lighting.hue) S\(environment.lighting.saturation) B\(environment.lighting.brightness)")
             print("[Gemini] 대화 주제: \(environment.conversations.count)개")
 
-            // TODO: HomeKit 조명 설정
-            isLightingReady = true
+            // HomeKit 조명 설정
+            if let controller = lightingController, let config = lightingConfig {
+                do {
+                    try await controller.applyLighting(config)
+                    print("[Lighting] 조명 설정 완료")
+                } catch {
+                    print("[Lighting] 조명 설정 실패: \(error.localizedDescription)")
+                }
+            }
+            isLightingReady = true // 조명 실패해도 독서 진행
 
             // AVFoundation 음악 재생
             if let category = musicCategory {
@@ -102,6 +113,17 @@ final class ReadingViewModel {
         timerTask = nil
         audioPlayerService.stop()
         isMusicPlaying = false
+
+        // 조명 리셋 (fire-and-forget)
+        if let controller = lightingController {
+            Task {
+                do {
+                    try await controller.resetLighting()
+                } catch {
+                    print("[Lighting] 조명 리셋 실패: \(error.localizedDescription)")
+                }
+            }
+        }
 
         guard let startTime else { return }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -11,6 +11,7 @@ enum HomeKitLightingError: LocalizedError, Sendable {
     case noHomesAvailable
     case noLightsFound
     case characteristicWriteFailed(String)
+    case homeLoadTimeout
 
     var errorDescription: String? {
         switch self {
@@ -20,6 +21,8 @@ enum HomeKitLightingError: LocalizedError, Sendable {
             return "제어 가능한 조명을 찾을 수 없습니다."
         case .characteristicWriteFailed(let detail):
             return "조명 값 쓰기 실패: \(detail)"
+        case .homeLoadTimeout:
+            return "HomeKit 집 데이터 로드 시간 초과"
         }
     }
 }
@@ -44,7 +47,7 @@ final class HomeKitLightingController: NSObject, LightingControllable {
     // MARK: - LightingControllable
 
     func applyLighting(_ config: LightingConfig) async throws {
-        let homes = await ensureHomesLoaded()
+        let homes = try await ensureHomesLoaded()
         guard let primaryHome = homes.first else {
             throw HomeKitLightingError.noHomesAvailable
         }
@@ -96,13 +99,26 @@ extension HomeKitLightingController: HMHomeManagerDelegate {
 
 private extension HomeKitLightingController {
 
-    /// HMHomeManager의 homes가 로드될 때까지 대기
-    func ensureHomesLoaded() async -> [HMHome] {
+    /// HMHomeManager의 homes가 로드될 때까지 대기 (타임아웃 10초)
+    func ensureHomesLoaded() async throws -> [HMHome] {
         if !homeManager.homes.isEmpty {
             return homeManager.homes
         }
-        return await withCheckedContinuation { continuation in
-            self.homesLoadedContinuation = continuation
+
+        return try await withThrowingTaskGroup(of: [HMHome].self) { group in
+            group.addTask { @MainActor in
+                await withCheckedContinuation { continuation in
+                    self.homesLoadedContinuation = continuation
+                }
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(10))
+                throw HomeKitLightingError.homeLoadTimeout
+            }
+
+            let result = try await group.next() ?? []
+            group.cancelAll()
+            return result
         }
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -1,0 +1,159 @@
+//
+//  HomeKitLightingController.swift
+//  LivingStory-iOS
+//
+
+import HomeKit
+
+// MARK: - Error
+
+enum HomeKitLightingError: LocalizedError, Sendable {
+    case noHomesAvailable
+    case noLightsFound
+    case characteristicWriteFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noHomesAvailable:
+            return "HomeKit에 등록된 집이 없습니다."
+        case .noLightsFound:
+            return "제어 가능한 조명을 찾을 수 없습니다."
+        case .characteristicWriteFailed(let detail):
+            return "조명 값 쓰기 실패: \(detail)"
+        }
+    }
+}
+
+// MARK: - Controller
+
+@MainActor
+final class HomeKitLightingController: NSObject, LightingControllable {
+
+    // MARK: - Properties
+
+    private let homeManager = HMHomeManager()
+    private var homesLoadedContinuation: CheckedContinuation<[HMHome], Never>?
+
+    // MARK: - Init
+
+    override init() {
+        super.init()
+        homeManager.delegate = self
+    }
+
+    // MARK: - LightingControllable
+
+    func applyLighting(_ config: LightingConfig) async throws {
+        let homes = await ensureHomesLoaded()
+        guard let primaryHome = homes.first else {
+            throw HomeKitLightingError.noHomesAvailable
+        }
+
+        let lightServices = findLightServices(in: primaryHome)
+        guard !lightServices.isEmpty else {
+            throw HomeKitLightingError.noLightsFound
+        }
+
+        // Best-effort: 가능한 만큼 적용, 전부 실패 시만 throw
+        var errors: [Error] = []
+        for service in lightServices {
+            do {
+                try await writeLightingValues(config, to: service)
+            } catch {
+                errors.append(error)
+                print("[HomeKit] 조명 적용 실패: \(error.localizedDescription)")
+            }
+        }
+
+        if errors.count == lightServices.count {
+            throw HomeKitLightingError.noLightsFound
+        }
+
+        print("[HomeKit] 조명 적용 완료 - H\(config.hue) S\(config.saturation) B\(config.brightness), \(lightServices.count - errors.count)/\(lightServices.count)개 성공")
+    }
+
+    func resetLighting() async throws {
+        try await applyLighting(.default)
+        print("[HomeKit] 조명 리셋 완료 (기본값)")
+    }
+}
+
+// MARK: - HMHomeManagerDelegate
+
+extension HomeKitLightingController: HMHomeManagerDelegate {
+
+    nonisolated func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
+        Task { @MainActor in
+            if let continuation = homesLoadedContinuation {
+                homesLoadedContinuation = nil
+                continuation.resume(returning: manager.homes)
+            }
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension HomeKitLightingController {
+
+    /// HMHomeManager의 homes가 로드될 때까지 대기
+    func ensureHomesLoaded() async -> [HMHome] {
+        if !homeManager.homes.isEmpty {
+            return homeManager.homes
+        }
+        return await withCheckedContinuation { continuation in
+            self.homesLoadedContinuation = continuation
+        }
+    }
+
+    /// 집 안의 모든 조명 서비스 찾기
+    func findLightServices(in home: HMHome) -> [HMService] {
+        home.accessories.compactMap { accessory in
+            accessory.services.first { $0.serviceType == HMServiceTypeLightbulb }
+        }
+    }
+
+    /// 조명 서비스에 HSB + 전원 값 쓰기
+    func writeLightingValues(_ config: LightingConfig, to service: HMService) async throws {
+        // 전원 켜기
+        if let powerChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypePowerState
+        }) {
+            try await writeCharacteristic(powerChar, value: true)
+        }
+
+        // 색상 (Hue) - 지원하는 조명만
+        if let hueChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeHue
+        }) {
+            try await writeCharacteristic(hueChar, value: Float(config.hue))
+        }
+
+        // 채도 (Saturation) - 지원하는 조명만
+        if let satChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeSaturation
+        }) {
+            try await writeCharacteristic(satChar, value: Float(config.saturation))
+        }
+
+        // 밝기 (Brightness) - 거의 모든 조명이 지원
+        if let brightChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeBrightness
+        }) {
+            try await writeCharacteristic(brightChar, value: config.brightness)
+        }
+    }
+
+    /// HMCharacteristic.writeValue completion handler를 async로 래핑
+    func writeCharacteristic(_ characteristic: HMCharacteristic, value: Any) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            characteristic.writeValue(value) { error in
+                if let error {
+                    continuation.resume(throwing: HomeKitLightingError.characteristicWriteFailed(error.localizedDescription))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #30 

## 📝 Summary
 독서 세션 시작 시 Gemini AI가 추천한 조명 설정(HSB)을 HomeKit 조명에 실시간으로 적용하고, 독서 종료 시 기본값(따뜻한 백색)으로 리셋하는 기능을 구현했습니다. POP 기반 `LightingControllable` 프로토콜로 Mock/Real 구현을 분리하고, `withCheckedThrowingContinuation`으로 HomeKit의 콜백 API를 Swift Concurrency로 래핑했습니다.

## 🔨 What

## 🏗 Architecture Decision (설계 의사결정)

  ### 1. HomeKitLightingController를 HomeKitManager와 분리
  - **문제**: 조명 쓰기 로직을 기존 `HomeKitManager`에 추가할지, 별도 클래스로 분리할지
  - **대안 검토**: HomeKitManager 확장 (한 곳에서 모든 HomeKit 처리 — SRP 위반, 변경 이유 2개)
  - **선택**: `HomeKitLightingController`를 별도 클래스로 생성. 
  HomeKitManager는 Home 탭 UI를 위한 **읽기/매핑** 전담, LightingController는 독서 세션 중 **쓰기** 전담. 각각 자체 `HMHomeManager` 인스턴스를 보유하여 의존성 없이 독립 동작

  ### 2. DI + POP로 Mock/Real 교체
  - **문제**: 시뮬레이터에 HomeKit 하드웨어가 없어 개발/테스트 불가
  - **대안 검토**: `#if DEBUG`로 ViewModel 내부에서 분기 (ViewModel이 구체 타입에 의존, 테스트 어려움)
  - **선택**: `LightingControllable` 프로토콜을 init에서 주입받아 ViewModel은 프로토콜만 의존. 
  AppCoordinator가 조립 시점에 `#if DEBUG` 분기로 Mock/Real 결정. 향후 SpyLightingController 주입으로 단위 테스트도
  가능

  ### 3. Graceful Degradation 패턴
  - **문제**: HomeKit 조명이 없는 환경에서 앱이 멈추면 안 됨
  - **선택**: 조명 적용 실패 시 catch → 로그만 출력 → `isLightingReady = true` 항상 도달. AudioPlayerService의 기존 패턴(`isMusicPlaying = true // 음원 실패해도 독서 진행`)과 동일한 전략 적용. 핵심 플로우(독서)를 부가 기능(조명)이 차단하지 않음
-> 릴리즈 버전으로 변경해서 푸시해놨어요. 그래서 혹시 목업으로 테스트하시길 원하시면 Product -> Scheme -> Edit Scheme -> Run -> info -> Release 를 Debug로 바꿔주세용 ㅎ

  ### 4. HMCharacteristic.writeValue async 래핑
  - **문제**: HomeKit API가 2015년 스타일 completion handler 기반
  - **대안 검토**: 콜백 그대로 사용 (콜백 지옥, Swift 6 Concurrency와 부조화)
  - **선택**: `withCheckedThrowingContinuation`으로 async throws 래핑. Power → Hue → Saturation → Brightness를 순차 await로 호출하여 각 특성 쓰기 완료를 보장

  ### 5. Best-effort 다중 조명 적용
  - **문제**: 집에 조명이 여러 개일 때, 하나 실패하면 전체를 중단할지
  - **선택**: 개별 조명마다 do/catch로 감싸서 실패 카운트 집계. 전부 실패한 경우에만 throw, 일부 성공이면 성공으로 처리. 거실 조명은 성공했는데 방 조명 하나 때문에 전체 실패 처리하는 것은 UX에 불합리

  ### 6. stopReading()에서 fire-and-forget Task
  - **문제**: `stopReading()`은 동기 메서드인데, `resetLighting()`은 async
  - **대안 검토**: stopReading()을 async로 변경 (호출부 전체 변경 필요, SwiftUI Button action에서 async 처리 복잡)
  - **선택**: `Task { try await controller.resetLighting() }`로 fire-and-forget. 조명 리셋은 사용자가 기다릴 필요 없는 작업이며, 화면 전환과 병렬로 진행해도 무방
  
  | 파일 | 역할 |
  |------|------|
  | `Service/HomeKitLightingController.swift` | `LightingControllable` 구현체. HMHomeManager로 조명 탐색 → HMCharacteristic으로 Power/Hue/Saturation/Brightness 쓰기. `withCheckedThrowingContinuation`으로 콜백
  async 래핑 |
  
   | 파일 | 변경 내용 |
  |------|---------|
  | `Presentation/Screens/Reading/ReadingViewModel.swift` | `lightingController: LightingControllable` DI 추가. `startSetup()`의 `// TODO: HomeKit 조명 설정` → 실제 `applyLighting()` 호출로 교체.
  `stopReading()`에 `resetLighting()` fire-and-forget Task 추가 |
  | `Application/Coordinator/AppCoordinator.swift` | `showReading(book:)`에서 `#if DEBUG` MockLightingController / `#else` HomeKitLightingController 분기 주입 |
  
  ## 🧪 테스트

  | 환경 | 검증 항목 | 방법 |
  |------|---------|------|
  | DEBUG + 시뮬레이터 | Mock 동작 | 콘솔에 `[MockLighting] 조명 적용 - H280 S50 B65` 출력 확인 |
  | DEBUG + 시뮬레이터 | Mock 리셋 | 독서 중단 시 `[MockLighting] 조명 리셋` 출력 확인 |
  | RELEASE + 실기기 | 실제 조명 적용 | HomeKit 등록된 조명에 HSB 값 적용 확인 |
  | 조명 없는 환경 | Graceful Degradation | 에러 로그 출력 후 독서 정상 진행 확인 |

  ---

  ## 🔧 Troubleshooting (트러블슈팅)

  ### 1. HMHomeManager.homes가 빈 배열로 반환
  - **원인**: `HMHomeManager` 초기화 직후 homes 데이터가 아직 로드되지 않음 (비동기 delegate 콜백으로 전달됨)
  - **해결**: `ensureHomesLoaded()`에서 `withCheckedContinuation` + `homeManagerDidUpdateHomes` delegate 조합으로 로딩 완료까지 suspend. 이미 로드된 경우 즉시 반환하는 fast path 포함

  ### 2. nonisolated delegate에서 @MainActor 프로퍼티 접근
  - **원인**: `HMHomeManagerDelegate.homeManagerDidUpdateHomes`는 non-isolated 메서드인데, `homesLoadedContinuation`은 `@MainActor` 클래스의 프로퍼티
  - **해결**: delegate 메서드에 `nonisolated` 명시 + 내부에서 `Task { @MainActor in }` 블록으로 actor hop하여 안전하게 continuation 접근

  ### 3. 색상 미지원 전구에서 writeValue 실패
  - **원인**: 밝기만 지원하는 전구(IKEA 백색 등)에 Hue/Saturation characteristic이 없음
  - **해결**: 각 characteristic을 `if let`으로 옵셔널 체크하여 지원하는 특성만 쓰기. 미지원 특성은 건너뜀 (에러 없음)

## 👀 Review Notes

  - **Swift 6 Concurrency**: `HomeKitLightingController`의 `@MainActor` + `nonisolated` delegate 조합 — actor isolation 위반 여부
  - **메모리 관리**: `HomeKitLightingController`가 ReadingViewModel에 strong reference로 유지됨 — 화면 pop 시 정상 해제 여부
  - **Continuation 안전성**: `ensureHomesLoaded()`에서 continuation이 정확히 1번만 resume되는지 — delegate가 여러 번 호출될 경우 대비 (`homesLoadedContinuation = nil` 선행 처리로 방어)
  - **Best-effort 에러 처리**: 전체 실패 판정 기준 (`errors.count == lightServices.count`) 의 적절성
