### PR TITLE
[Feat][PO-51] HomeKit 디바이스 실시간 상태 업데이트

### DIFF
--- a/LivingStory-iOS/Info.plist
+++ b/LivingStory-iOS/Info.plist
@@ -16,12 +16,16 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
 	<key>GEMINI_API_KEY</key>
 	<string>$(GEMINI_API_KEY)</string>
 	<key>KAKAO_REST_API_KEY</key>
 	<string>$(KAKAO_REST_API_KEY)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>com.apple.home</string>
+	</array>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>책 바코드를 스캔하기 위해 카메라 접근이 필요합니다.</string>
 	<key>NSHomeKitUsageDescription</key>

--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5EA4DF22F1DFC6B004FF6C7"
+               BuildableName = "LivingStory-iOS.app"
+               BlueprintName = "LivingStory-iOS"
+               ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5EA4E0B2F1DFC6C004FF6C7"
+               BuildableName = "LivingStory-iOSTests.xctest"
+               BlueprintName = "LivingStory-iOSTests"
+               ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5EA4E152F1DFC6C004FF6C7"
+               BuildableName = "LivingStory-iOSUITests.xctest"
+               BlueprintName = "LivingStory-iOSUITests"
+               ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5EA4DF22F1DFC6B004FF6C7"
+            BuildableName = "LivingStory-iOS.app"
+            BlueprintName = "LivingStory-iOS"
+            ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5EA4DF22F1DFC6B004FF6C7"
+            BuildableName = "LivingStory-iOS.app"
+            BlueprintName = "LivingStory-iOS"
+            ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -101,7 +101,17 @@ final class AppCoordinator: Coordinator {
 
     /// 독서 중 화면 (SwiftUI)
     func showReading(book: BookProfileModel) {
-        let viewModel = ReadingViewModel(book: book)
+        let lightingController: any LightingControllable
+        #if DEBUG
+        lightingController = MockLightingController()
+        #else
+        lightingController = HomeKitLightingController()
+        #endif
+
+        let viewModel = ReadingViewModel(
+            book: book,
+            lightingController: lightingController
+        )
         let view = ReadingView(coordinator: self, viewModel: viewModel)
         let hostingVC = UIHostingController(rootView: view)
         (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
@@ -60,6 +60,14 @@ final class HomeDataSource {
             snapshot.appendSections([room])
             snapshot.appendItems(room.devices, toSection: room)
         }
+
+        // 기존 아이템의 콘텐츠도 갱신 (isOn, percentage 변경 반영)
+        let existingItems = diffableDataSource.snapshot().itemIdentifiers
+        let itemsToReconfigure = snapshot.itemIdentifiers.filter { existingItems.contains($0) }
+        if !itemsToReconfigure.isEmpty {
+            snapshot.reconfigureItems(itemsToReconfigure)
+        }
+
         diffableDataSource.apply(snapshot, animatingDifferences: true)
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
@@ -17,6 +17,7 @@ final class HomeViewController: UIViewController {
     private let homeDataSource = HomeDataSource()
     private var homes: [HomeModel] = []
     private var currentHome: HomeModel?
+    private var currentEmptyState: HomeState = .noDevices
 
     private let homeMenuButton: UIButton = {
         let button = UIButton(type: .system)
@@ -106,7 +107,15 @@ private extension HomeViewController {
 
     func setupEmptyStateActions() {
         emptyStateView.onButtonTapped = { [weak self] in
-            self?.openSettings()
+            guard let self else { return }
+            switch self.currentEmptyState {
+            case .permissionsRequired:
+                self.openSettings()
+            case .noDevices:
+                self.openHomeApp()
+            case .normal:
+                break
+            }
         }
     }
 
@@ -164,7 +173,12 @@ private extension HomeViewController {
             guard let self else { return }
             self.homes = homes
 
-            if let first = homes.first {
+            // 현재 선택된 집 유지 (실시간 업데이트 시 리셋 방지)
+            if let selectedId = self.currentHome?.id,
+               let updated = homes.first(where: { $0.id == selectedId }) {
+                self.currentHome = updated
+                self.updateUI(for: updated.state)
+            } else if let first = homes.first {
                 self.currentHome = first
                 self.updateUI(for: first.state)
             } else {
@@ -186,6 +200,7 @@ private extension HomeViewController {
 private extension HomeViewController {
 
     func updateUI(for state: HomeState) {
+        currentEmptyState = state
         updateHomeMenu()
 
         switch state {
@@ -251,6 +266,15 @@ private extension HomeViewController {
 
     func openSettings() {
         guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    func openHomeApp() {
+        guard let url = URL(string: "com.apple.home://"),
+              UIApplication.shared.canOpenURL(url) else {
+            openSettings()
+            return
+        }
         UIApplication.shared.open(url)
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -137,6 +137,7 @@ struct ReadingView: View {
     }
 }
 
+#if DEBUG
 #Preview("독서 중") {
     NavigationView {
         ReadingView(
@@ -149,3 +150,4 @@ struct ReadingView: View {
         )
     }
 }
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -26,6 +26,7 @@ final class ReadingViewModel {
     private let audioPlayerService: AudioPlayerService
     private let bookRepository: BookRepositoryProtocol
     private let sessionRepository: ReadingSessionRepositoryProtocol
+    private let lightingController: (any LightingControllable)?
     private var timerTask: Task<Void, Never>?
     private var startTime: Date?
     private var hasStarted = false
@@ -35,13 +36,15 @@ final class ReadingViewModel {
         geminiService: GeminiService? = nil,
         audioPlayerService: AudioPlayerService? = nil,
         bookRepository: BookRepositoryProtocol? = nil,
-        sessionRepository: ReadingSessionRepositoryProtocol? = nil
+        sessionRepository: ReadingSessionRepositoryProtocol? = nil,
+        lightingController: (any LightingControllable)? = nil
     ) {
         self.book = book
         self.geminiService = geminiService ?? GeminiService()
         self.audioPlayerService = audioPlayerService ?? AudioPlayerService()
         self.bookRepository = bookRepository ?? BookRepository()
         self.sessionRepository = sessionRepository ?? ReadingSessionRepository()
+        self.lightingController = lightingController
     }
 
     // MARK: - Public
@@ -69,8 +72,16 @@ final class ReadingViewModel {
             print("[Gemini] 조명: H\(environment.lighting.hue) S\(environment.lighting.saturation) B\(environment.lighting.brightness)")
             print("[Gemini] 대화 주제: \(environment.conversations.count)개")
 
-            // TODO: HomeKit 조명 설정
-            isLightingReady = true
+            // HomeKit 조명 설정
+            if let controller = lightingController, let config = lightingConfig {
+                do {
+                    try await controller.applyLighting(config)
+                    print("[Lighting] 조명 설정 완료")
+                } catch {
+                    print("[Lighting] 조명 설정 실패: \(error.localizedDescription)")
+                }
+            }
+            isLightingReady = true // 조명 실패해도 독서 진행
 
             // AVFoundation 음악 재생
             if let category = musicCategory {
@@ -102,6 +113,17 @@ final class ReadingViewModel {
         timerTask = nil
         audioPlayerService.stop()
         isMusicPlaying = false
+
+        // 조명 리셋 (fire-and-forget)
+        if let controller = lightingController {
+            Task {
+                do {
+                    try await controller.resetLighting()
+                } catch {
+                    print("[Lighting] 조명 리셋 실패: \(error.localizedDescription)")
+                }
+            }
+        }
 
         guard let startTime else { return }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -11,6 +11,7 @@ enum HomeKitLightingError: LocalizedError, Sendable {
     case noHomesAvailable
     case noLightsFound
     case characteristicWriteFailed(String)
+    case homeLoadTimeout
 
     var errorDescription: String? {
         switch self {
@@ -20,6 +21,8 @@ enum HomeKitLightingError: LocalizedError, Sendable {
             return "제어 가능한 조명을 찾을 수 없습니다."
         case .characteristicWriteFailed(let detail):
             return "조명 값 쓰기 실패: \(detail)"
+        case .homeLoadTimeout:
+            return "HomeKit 집 데이터 로드 시간 초과"
         }
     }
 }
@@ -44,7 +47,7 @@ final class HomeKitLightingController: NSObject, LightingControllable {
     // MARK: - LightingControllable
 
     func applyLighting(_ config: LightingConfig) async throws {
-        let homes = await ensureHomesLoaded()
+        let homes = try await ensureHomesLoaded()
         guard let primaryHome = homes.first else {
             throw HomeKitLightingError.noHomesAvailable
         }
@@ -96,13 +99,26 @@ extension HomeKitLightingController: HMHomeManagerDelegate {
 
 private extension HomeKitLightingController {
 
-    /// HMHomeManager의 homes가 로드될 때까지 대기
-    func ensureHomesLoaded() async -> [HMHome] {
+    /// HMHomeManager의 homes가 로드될 때까지 대기 (타임아웃 10초)
+    func ensureHomesLoaded() async throws -> [HMHome] {
         if !homeManager.homes.isEmpty {
             return homeManager.homes
         }
-        return await withCheckedContinuation { continuation in
-            self.homesLoadedContinuation = continuation
+
+        return try await withThrowingTaskGroup(of: [HMHome].self) { group in
+            group.addTask { @MainActor in
+                await withCheckedContinuation { continuation in
+                    self.homesLoadedContinuation = continuation
+                }
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(10))
+                throw HomeKitLightingError.homeLoadTimeout
+            }
+
+            let result = try await group.next() ?? []
+            group.cancelAll()
+            return result
         }
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -1,0 +1,159 @@
+//
+//  HomeKitLightingController.swift
+//  LivingStory-iOS
+//
+
+import HomeKit
+
+// MARK: - Error
+
+enum HomeKitLightingError: LocalizedError, Sendable {
+    case noHomesAvailable
+    case noLightsFound
+    case characteristicWriteFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noHomesAvailable:
+            return "HomeKit에 등록된 집이 없습니다."
+        case .noLightsFound:
+            return "제어 가능한 조명을 찾을 수 없습니다."
+        case .characteristicWriteFailed(let detail):
+            return "조명 값 쓰기 실패: \(detail)"
+        }
+    }
+}
+
+// MARK: - Controller
+
+@MainActor
+final class HomeKitLightingController: NSObject, LightingControllable {
+
+    // MARK: - Properties
+
+    private let homeManager = HMHomeManager()
+    private var homesLoadedContinuation: CheckedContinuation<[HMHome], Never>?
+
+    // MARK: - Init
+
+    override init() {
+        super.init()
+        homeManager.delegate = self
+    }
+
+    // MARK: - LightingControllable
+
+    func applyLighting(_ config: LightingConfig) async throws {
+        let homes = await ensureHomesLoaded()
+        guard let primaryHome = homes.first else {
+            throw HomeKitLightingError.noHomesAvailable
+        }
+
+        let lightServices = findLightServices(in: primaryHome)
+        guard !lightServices.isEmpty else {
+            throw HomeKitLightingError.noLightsFound
+        }
+
+        // Best-effort: 가능한 만큼 적용, 전부 실패 시만 throw
+        var errors: [Error] = []
+        for service in lightServices {
+            do {
+                try await writeLightingValues(config, to: service)
+            } catch {
+                errors.append(error)
+                print("[HomeKit] 조명 적용 실패: \(error.localizedDescription)")
+            }
+        }
+
+        if errors.count == lightServices.count {
+            throw HomeKitLightingError.noLightsFound
+        }
+
+        print("[HomeKit] 조명 적용 완료 - H\(config.hue) S\(config.saturation) B\(config.brightness), \(lightServices.count - errors.count)/\(lightServices.count)개 성공")
+    }
+
+    func resetLighting() async throws {
+        try await applyLighting(.default)
+        print("[HomeKit] 조명 리셋 완료 (기본값)")
+    }
+}
+
+// MARK: - HMHomeManagerDelegate
+
+extension HomeKitLightingController: HMHomeManagerDelegate {
+
+    nonisolated func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
+        Task { @MainActor in
+            if let continuation = homesLoadedContinuation {
+                homesLoadedContinuation = nil
+                continuation.resume(returning: manager.homes)
+            }
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension HomeKitLightingController {
+
+    /// HMHomeManager의 homes가 로드될 때까지 대기
+    func ensureHomesLoaded() async -> [HMHome] {
+        if !homeManager.homes.isEmpty {
+            return homeManager.homes
+        }
+        return await withCheckedContinuation { continuation in
+            self.homesLoadedContinuation = continuation
+        }
+    }
+
+    /// 집 안의 모든 조명 서비스 찾기
+    func findLightServices(in home: HMHome) -> [HMService] {
+        home.accessories.compactMap { accessory in
+            accessory.services.first { $0.serviceType == HMServiceTypeLightbulb }
+        }
+    }
+
+    /// 조명 서비스에 HSB + 전원 값 쓰기
+    func writeLightingValues(_ config: LightingConfig, to service: HMService) async throws {
+        // 전원 켜기
+        if let powerChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypePowerState
+        }) {
+            try await writeCharacteristic(powerChar, value: true)
+        }
+
+        // 색상 (Hue) - 지원하는 조명만
+        if let hueChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeHue
+        }) {
+            try await writeCharacteristic(hueChar, value: Float(config.hue))
+        }
+
+        // 채도 (Saturation) - 지원하는 조명만
+        if let satChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeSaturation
+        }) {
+            try await writeCharacteristic(satChar, value: Float(config.saturation))
+        }
+
+        // 밝기 (Brightness) - 거의 모든 조명이 지원
+        if let brightChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeBrightness
+        }) {
+            try await writeCharacteristic(brightChar, value: config.brightness)
+        }
+    }
+
+    /// HMCharacteristic.writeValue completion handler를 async로 래핑
+    func writeCharacteristic(_ characteristic: HMCharacteristic, value: Any) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            characteristic.writeValue(value) { error in
+                if let error {
+                    continuation.resume(throwing: HomeKitLightingError.characteristicWriteFailed(error.localizedDescription))
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -12,6 +12,7 @@ final class HomeKitManager: NSObject {
     // MARK: - Properties
 
     private let homeManager = HMHomeManager()
+    private var pendingUpdateWorkItem: DispatchWorkItem?
 
     /// HomeKit에서 집 목록이 업데이트되면 호출되는 콜백
     var onHomesUpdated: (([HomeModel]) -> Void)?
@@ -43,6 +44,10 @@ extension HomeKitManager: HMHomeManagerDelegate {
             return
         }
 
+        for home in manager.homes {
+            registerForNotifications(in: home)
+        }
+
         let homes = manager.homes.map { mapHome($0) }
         DispatchQueue.main.async { [weak self] in
             self?.onHomesUpdated?(homes)
@@ -50,9 +55,62 @@ extension HomeKitManager: HMHomeManagerDelegate {
     }
 }
 
+// MARK: - HMAccessoryDelegate
+
+extension HomeKitManager: HMAccessoryDelegate {
+
+    /// 액세서리의 특성 값이 변경되면 호출 (외부 앱, 자동화, 물리 제어 등)
+    func accessory(_ accessory: HMAccessory, service: HMService,
+                   didUpdateValueFor characteristic: HMCharacteristic) {
+        // 쓰로틀링: 150ms 내 여러 변경을 하나로 합침 (밝기 슬라이더 등)
+        pendingUpdateWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            let homes = self.homeManager.homes.map { self.mapHome($0) }
+            self.onHomesUpdated?(homes)
+        }
+        pendingUpdateWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: workItem)
+    }
+}
+
 // MARK: - Private Mapping
 
 private extension HomeKitManager {
+
+    // MARK: - Notification Registration
+
+    /// 집 안 모든 액세서리에 delegate 설정 + 특성 변경 알림 구독
+    func registerForNotifications(in home: HMHome) {
+        for room in home.rooms {
+            for accessory in room.accessories {
+                accessory.delegate = self
+                enableNotifications(for: accessory)
+            }
+        }
+    }
+
+    /// 특성 값 변경 이벤트 알림 활성화 (전원, 밝기, 볼륨)
+    func enableNotifications(for accessory: HMAccessory) {
+        let subscribableTypes: Set<String> = [
+            HMCharacteristicTypePowerState,
+            HMCharacteristicTypeBrightness,
+            HMCharacteristicTypeVolume
+        ]
+        for service in accessory.services {
+            for characteristic in service.characteristics where
+                subscribableTypes.contains(characteristic.characteristicType) &&
+                characteristic.properties.contains(HMCharacteristicPropertySupportsEventNotification) {
+                characteristic.enableNotification(true) { error in
+                    if let error {
+                        print("[HomeKit] 알림 활성화 실패 (\(accessory.name)): \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Mapping
 
     /// HMHome → HomeModel 변환
     func mapHome(_ hmHome: HMHome) -> HomeModel {

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -62,7 +62,7 @@ extension HomeKitManager: HMAccessoryDelegate {
     /// 액세서리의 특성 값이 변경되면 호출 (외부 앱, 자동화, 물리 제어 등)
     func accessory(_ accessory: HMAccessory, service: HMService,
                    didUpdateValueFor characteristic: HMCharacteristic) {
-        // 쓰로틀링: 150ms 내 여러 변경을 하나로 합침 (밝기 슬라이더 등)
+        // 디바운싱: 150ms 내 연속 변경을 최종 1회로 합침 (밝기 슬라이더 등)
         pendingUpdateWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #32 

## 📝 Summary
- HomeKit 디바이스의 실시간 상태 변경을 HMAccessoryDelegate로 감지하고, DispatchWorkItem 기반 디바운싱으로 rapid-fire 이벤트를 최적화하여 Home 탭 UI에 즉시 반영하는 기능을 구현했습니다.

## 🏗 Architecture Decision (설계 의사결정)

  ### 1. 실시간 상태 감지 방식 선택
  - **문제**: 홈앱이나 Siri, 물리 스위치로 디바이스 상태가 변경되어도 앱 UI에 반영 안 됨
  - **대안 검토**: 타이머 폴링 (비효율, 배터리 낭비) / App Intents (방향이 반대 — 앱→시스템 노출용)
  - **선택**: `HMAccessoryDelegate` + `enableNotification(true)` — HomeKit homed 데몬이 HAP/Matter 프로토콜로 디바이스 상태를 추적하고, XPC를 통해 앱에 push하는 이벤트 드리븐 구조 활용

  ### 2. 디바운싱 vs 쓰로틀링
  - **문제**: 밝기 슬라이더 드래그 시 매 프레임(~16ms)마다 delegate 콜백 발생 → UI 과부하
  - **대안 검토**: 쓰로틀링 (일정 간격마다 중간값 반영) / Combine debounce (UIKit 프로젝트에서 오버엔지니어링)
  - **선택**: `DispatchWorkItem` cancel/reschedule 패턴의 디바운싱 (150ms) — 중간값이 무의미하고 최종 상태만 필요하므로, 이벤트가 멈춘 후 1회만 UI 갱신

  ### 3. DiffableDataSource 셀 콘텐츠 갱신
  - **문제**: `DeviceModel`의 `Equatable`이 id 기반이라, isOn/percentage가 바뀌어도 DiffableDataSource가 "같은 아이템"으로 판단하여 셀 갱신 안 됨
  - **대안 검토**: `reloadItems` (셀 인스턴스 재생성 — 깜빡임) / Equatable에 isOn/percentage 추가 (삽입+삭제 애니메이션 발생)
  - **선택**: `reconfigureItems` — 기존 셀 인스턴스를 재사용하면서 콘텐츠만 업데이트하므로 자연스러운 애니메이션 유지

  ### 4. GCD vs async/await
  - **문제**: HMAccessoryDelegate는 Obj-C 동기 콜백, 이 안에서 디바운싱 필요
  - **대안 검토**: `Task.sleep` + `Task.cancel` (CancellationError catch 필요, 코드 복잡)
  - **선택**: `DispatchWorkItem` + `asyncAfter` — 동기 delegate 콜백 내 타이머 패턴에서 GCD가 3줄로 간결

  ### 5. 빈 화면 버튼 상태별 분기
  - **문제**: "홈앱 열기" 버튼이 권한 미허용/기기 없음 상태 모두에서 설정 앱으로 이동
  - **선택**: `currentEmptyState` 프로퍼티로 상태 추적, `.permissionsRequired` → 설정 앱, `.noDevices` → 홈앱 (`com.apple.home://` URL Scheme + `canOpenURL` fallback)

## 🔨 What
| 파일 | 변경 내용 |
  |------|----------|
  | `HomeKitManager.swift` | HMAccessoryDelegate 채택, `enableNotification` 구독, `DispatchWorkItem` 디바운싱 콜백, `registerForNotifications`/`enableNotifications` 헬퍼 |
  | `HomeDataSource.swift` | `applySnapshot`에 `reconfigureItems` 추가 (기존 아이템 콘텐츠 갱신) |
  | `HomeViewController.swift` | `currentHome.id` 매칭으로 선택된 집 유지, `currentEmptyState` 상태별 버튼 분기, `openHomeApp()` 추가 |
  | `Info.plist` | `LSApplicationQueriesSchemes`에 `com.apple.home` 등록 |

 ## 🔧 Troubleshooting (트러블슈팅)

  ### 1. 빈 화면 버튼이 항상 설정 앱으로 이동
  - **원인**: `setupEmptyStateActions`에서 `onButtonTapped`이 상태와 무관하게 `openSettings()` 고정 호출
  - **해결**: `currentEmptyState` 프로퍼티 추가, switch 분기로 `.permissionsRequired` → 설정, `.noDevices` → 홈앱

  ### 2. canOpenURL이 항상 false 반환
  - **원인**: iOS 9+부터 `canOpenURL`은 `LSApplicationQueriesSchemes`에 등록된 URL Scheme만 조회 가능
  - **해결**: Info.plist에 `com.apple.home` 등록, 실패 시 `openSettings()` fallback

  ---

  ## 🔮 Future Work
  - 앱 실행 중 새 액세서리 추가 시 자동 구독 (`HMHomeDelegate.home(_:didAdd:)`)
  - HomeKit Accessory Simulator로 가상 디바이스 테스트 자동화
  - PO-50 연동 검증: 독서 종료 → Home 탭 복귀 시 조명 리셋 상태 반영

## 👀 Review Notes
- [x] **HomeKitManager.swift**: `accessory(_:service:didUpdateValueFor:)` 디바운싱 로직 — DispatchWorkItem cancel/reschedule 패턴이 race condition 없는지 확인
- [x]  **HomeDataSource.swift**: `reconfigureItems` 호출 시 기존 스냅샷이 비어있는 최초 호출 케이스에서 빈 배열 필터링 정상 동작 여부 
- [x] **HomeViewController.swift**: `openHomeApp()` URL Scheme이 undocumented — App Review에서 리젝 가능성 검토 필요