### PR TITLE
[Feat] #PO-54 독서 플로우 네비게이션 정리 및 실제 Gemini API 연동

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -96,6 +96,7 @@ final class AppCoordinator: Coordinator {
     func showBookProfile(book: BookProfileModel) {
         let view = BookProfileView(coordinator: self, book: book)
         let hostingVC = UIHostingController(rootView: view)
+        hostingVC.hidesBottomBarWhenPushed = true
         activeNavigationController?.pushViewController(hostingVC, animated: true)
     }
 
@@ -124,7 +125,37 @@ final class AppCoordinator: Coordinator {
 
     /// 홈으로 돌아가기
     func popToHome() {
-        navigationController.popToRootViewController(animated: true)
+        activeNavigationController?.popToRootViewController(animated: true)
+    }
+
+    /// 현재 화면 위에 바코드 스캔 시트 재호출 (독서 플로우 중 "다른 책 스캔")
+    func restartScanner() {
+        guard let nav = activeNavigationController else { return }
+
+        let vc = ScannerViewController()
+        vc.coordinator = self
+        vc.isRestarting = true
+
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [vc.scanningDetent]
+            sheet.preferredCornerRadius = 32
+        }
+
+        // 현재 화면(StopReadingView) 위에 스캐너 present
+        nav.topViewController?.present(vc, animated: true)
+    }
+
+    /// 기존 독서 스택 정리 후 새 책 BookProfileView로 교체
+    func replaceReadingFlow(with book: BookProfileModel) {
+        guard let nav = activeNavigationController else { return }
+        // 루트(BookViewController)만 남기고 새 BookProfileView push
+        let view = BookProfileView(coordinator: self, book: book)
+        let hostingVC = UIHostingController(rootView: view)
+        hostingVC.hidesBottomBarWhenPushed = true
+
+        var viewControllers = [nav.viewControllers.first].compactMap { $0 }
+        viewControllers.append(hostingVC)
+        nav.setViewControllers(viewControllers, animated: true)
     }
 
     /// 통계 화면 (SwiftUI)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Book/BookViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Book/BookViewController.swift
@@ -149,9 +149,3 @@ private extension BookViewController {
         coordinator?.showScanner()
     }
 }
-
-// MARK: - Preview
-
-#Preview {
-    UINavigationController(rootViewController: BookViewController())
-}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Book/Views/CarouselCell.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Book/Views/CarouselCell.swift
@@ -116,7 +116,3 @@ private extension CarouselCell {
         ])
     }
 }
-
-#Preview {
-    BookViewController()
-}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
@@ -82,14 +82,3 @@ private struct BookCoverSection: View {
         .frame(height: height)
     }
 }
-
-// MARK: - Preview
-
-#Preview {
-    NavigationView {
-        BookProfileView(
-            coordinator: AppCoordinator(navigationController: UINavigationController()),
-            book: .mock
-        )
-    }
-}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -118,34 +118,10 @@ struct ReadingView: View {
                 )
                 .frame(width: 610, height: 610)
                 .scaleEffect(isPulsing ? 1.0 : 0.85)
-                .opacity(isPulsing ? 0.3 : 0.05)
+                .opacity(isPulsing ? 0.4 : 0.1)
                 .blur(radius: 50)
                 .animation(.easeInOut(duration: 1.5), value: viewModel.state)
         }
         .ignoresSafeArea()
-    }
-}
-
-// MARK: - Preview
-
-#Preview("세팅 중") {
-    NavigationView {
-        ReadingView(
-            coordinator: AppCoordinator(navigationController: UINavigationController()),
-            viewModel: ReadingViewModel(book: .mock)
-        )
-    }
-}
-
-#Preview("독서 중") {
-    NavigationView {
-        ReadingView(
-            coordinator: AppCoordinator(navigationController: UINavigationController()),
-            viewModel: {
-                let vm = ReadingViewModel(book: .mock)
-                vm.setState(.reading)
-                return vm
-            }()
-        )
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -55,11 +55,7 @@ final class ReadingViewModel {
         print("[Gemini] API 요청 시작 (1회)")
 
         do {
-            #if DEBUG
-            let environment = ReadingEnvironment.mock
-            #else
             let environment = try await geminiService.generateReadingEnvironment(for: book)
-            #endif
 
             musicCategory = environment.musicCategory
             lightingConfig = environment.lighting
@@ -77,9 +73,7 @@ final class ReadingViewModel {
                 do {
                     try audioPlayerService.play(category: category)
                     isMusicPlaying = true
-                    print("[Audio] \(category.rawValue) 재생 시작")
                 } catch {
-                    print("[Audio] 재생 실패: \(error.localizedDescription)")
                     isMusicPlaying = true // 음원 실패해도 독서 진행
                 }
             } else {
@@ -126,12 +120,9 @@ final class ReadingViewModel {
         do {
             try bookRepository.saveBook(book)
             try sessionRepository.saveSession(session, bookISBN: book.isbn)
-            print("[Session] 독서 기록 저장 - \(durationMinutes)분")
         } catch {
-            print("[Session] 저장 실패: \(error)")
+            print("[Gemini] 세션 저장 실패: \(error)")
         }
-
-        print("[Audio] 재생 중단")
     }
 
     // MARK: - Private
@@ -146,11 +137,3 @@ final class ReadingViewModel {
         }
     }
 }
-
-#if DEBUG
-extension ReadingViewModel {
-    func setState(_ state: ReadingState) {
-        self.state = state
-    }
-}
-#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -57,12 +57,3 @@ struct ResultView: View {
         )
     }
 }
-
-#Preview {
-    NavigationView {
-        ResultView(
-            coordinator: AppCoordinator(navigationController: UINavigationController()),
-            repository: ReadingSessionRepository()
-        )
-    }
-}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -45,7 +45,9 @@ struct StopReadingView: View {
 
     private var buttonSection: some View {
         VStack(spacing: 14) {
-            PrimaryButtonSwiftUI(title: "다른 책 스캔", action: {})
+            PrimaryButtonSwiftUI(title: "다른 책 스캔", action: {
+                    coordinator.restartScanner()
+                })
                 .padding(.horizontal, 20)
             WhiteButtonSwiftUI(title: "그만 읽기", action: {
                     coordinator.showResult()

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -81,13 +81,3 @@ private struct ConversationCard: View {
         .clipShape(RoundedRectangle(cornerRadius: 18))
     }
 }
-
-#Preview {
-    NavigationView {
-        StopReadingView(
-            coordinator: AppCoordinator(navigationController: UINavigationController()),
-            bookTitle: "냉장고 먹는 괴물",
-            conversations: ConversationProfile.mockList
-        )
-    }
-}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
@@ -23,6 +23,8 @@ final class ScannerViewController: UIViewController {
     // MARK: - Properties
 
     weak var coordinator: AppCoordinator?
+    /// 독서 플로우 중 "다른 책 스캔"으로 열린 경우 true
+    var isRestarting = false
 
     private var state: ScannerState = .scanning {
         didSet { transition(to: state) }
@@ -211,7 +213,11 @@ private extension ScannerViewController {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
                 guard let self, let book = self.fetchedBook else { return }
                 self.dismiss(animated: true) {
-                    self.coordinator?.showBookProfile(book: book)
+                    if self.isRestarting {
+                        self.coordinator?.replaceReadingFlow(with: book)
+                    } else {
+                        self.coordinator?.showBookProfile(book: book)
+                    }
                 }
             }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerResultContentView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerResultContentView.swift
@@ -103,40 +103,6 @@ final class ScannerResultContentView: UIView {
         retryButton.isHidden = !showRetry
     }
 
-    func configureForPreview(state: ScannerState) {
-        isHidden = false
-
-        switch state {
-        case .scanning:
-            break
-
-        case .recognizing:
-            resetState()
-            statusLabel.text = StringLiterals.Scanner.recognizing + "..."
-            statusLabel.textColor = UIColor(named: "gray50")
-
-        case .success:
-            let config = UIImage.SymbolConfiguration(pointSize: 106, weight: .regular)
-            barcodeIconView.image = UIImage(.checkmarkCircle)?.withConfiguration(config)
-            barcodeIconView.tintColor = .systemGreen
-            statusLabel.text = StringLiterals.Scanner.success
-            statusLabel.textColor = .systemGreen
-            successIcon.isHidden = false
-            failedIcon.isHidden = true
-            retryButton.isHidden = true
-
-        case .failed:
-            let config = UIImage.SymbolConfiguration(pointSize: 106, weight: .regular)
-            barcodeIconView.image = UIImage(.scanner)?.withConfiguration(config)
-            barcodeIconView.tintColor = UIColor(named: "gray0")
-            statusLabel.text = StringLiterals.Scanner.failed
-            statusLabel.textColor = .systemRed
-            failedIcon.isHidden = false
-            successIcon.isHidden = true
-            retryButton.isHidden = false
-            retryButton.alpha = 1
-        }
-    }
 }
 
 // MARK: - Setup
@@ -169,54 +135,4 @@ private extension ScannerResultContentView {
             retryButton.heightAnchor.constraint(equalToConstant: 56),
         ])
     }
-}
-
-// MARK: - Preview
-
-#Preview("인식중") {
-    let vc = UIViewController()
-    vc.view.backgroundColor = .white
-    let resultView = ScannerResultContentView()
-    resultView.configureForPreview(state: .recognizing)
-    vc.view.addSubview(resultView)
-    resultView.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-        resultView.topAnchor.constraint(equalTo: vc.view.safeAreaLayoutGuide.topAnchor, constant: 50),
-        resultView.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
-        resultView.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
-        resultView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor),
-    ])
-    return vc
-}
-
-#Preview("인식 완료") {
-    let vc = UIViewController()
-    vc.view.backgroundColor = .white
-    let resultView = ScannerResultContentView()
-    resultView.configureForPreview(state: .success)
-    vc.view.addSubview(resultView)
-    resultView.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-        resultView.topAnchor.constraint(equalTo: vc.view.safeAreaLayoutGuide.topAnchor, constant: 50),
-        resultView.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
-        resultView.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
-        resultView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor),
-    ])
-    return vc
-}
-
-#Preview("인식 실패") {
-    let vc = UIViewController()
-    vc.view.backgroundColor = .white
-    let resultView = ScannerResultContentView()
-    resultView.configureForPreview(state: .failed)
-    vc.view.addSubview(resultView)
-    resultView.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-        resultView.topAnchor.constraint(equalTo: vc.view.safeAreaLayoutGuide.topAnchor, constant: 50),
-        resultView.leadingAnchor.constraint(equalTo: vc.view.leadingAnchor),
-        resultView.trailingAnchor.constraint(equalTo: vc.view.trailingAnchor),
-        resultView.bottomAnchor.constraint(equalTo: vc.view.bottomAnchor),
-    ])
-    return vc
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -107,14 +107,3 @@ struct StatCard: View {
         .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
     }
 }
-
-// MARK: - Preview
-
-#Preview {
-    NavigationView {
-        StatisticsView(
-            coordinator: AppCoordinator(navigationController: UINavigationController()),
-            repository: ReadingSessionRepository()
-        )
-    }
-}


### PR DESCRIPTION
- Closes #36

## 📝 Summary
독서 플로우의 네비게이션 문제를 수정하고, DEBUG mock을 제거하여 실제 Gemini API를 호출하도록 전환했습니다. 전체 Preview 코드도 정리했습니다.

## 🔨 What
1. **BookProfileView 탭바 숨김** — `hidesBottomBarWhenPushed = true` 적용, 독서 플로우 진입 시 하단 탭바 제거
2. **StopReadingView "다른 책 스캔"** — 현재 화면 위에 스캐너 시트 present → 인식 성공 시 기존 스택 교체(`replaceReadingFlow`)
3. **ResultView "홈으로"** — `popToHome()`이 `activeNavigationController`를 사용하도록 수정
4. **AppCoordinator 확장** — `restartScanner()`, `replaceReadingFlow(with:)` 메서드 추가
5. **ScannerViewController 분기** — `isRestarting` 플래그로 초기 스캔/재스캔 동작 분리
6. **Gemini mock 제거** — `#if DEBUG ReadingEnvironment.mock` 분기 제거 → 실제 API 호출
7. **Preview 전체 제거** — 8개 파일에서 #Preview 블록 및 configureForPreview 메서드 삭제
8. **디버그 print 정리** — Audio/Session print 제거, Gemini 관련 print만 유지
9. **ReadingView 펄스 배경** — opacity 상향 조정 (0.3/0.05 → 0.4/0.1)

## 📸 Screenshots
스크린샷 추후 추가 예정

## 👀 Review Notes
- Gemini API가 fantasy 외 카테고리를 반환할 경우 해당 오디오 에셋이 없어 재생 실패하지만, fallback 처리로 독서 진행에는 문제 없음
- HomeKit 조명 연동은 아직 TODO 상태
- `#if DEBUG` setState는 삭제됨 (Preview 제거에 따른 불필요 코드)