### PR TITLE
[Feat][PO-55] My 탭 구현 ( 커스텀 캘린더 + 독서 통계 )

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
@@ -1,4 +1,447 @@
+import UIKit
 import SwiftUI
+
+// MARK: - Shared Format Style
+
+/// Date.FormatStyle: iOS 15+ 권장, value type + Sendable + 내부 캐싱
+private let monthYearFormatStyle = Date.FormatStyle()
+    .month(.wide)
+    .year(.defaultDigits)
+    .locale(Locale(identifier: "en_US"))
+
+// MARK: - UIKit Version
+
+final class ReadingLogCalendarUIView: UIView {
+
+    // MARK: - Properties
+
+    private var displayedMonth = Date()
+    private var readDates: Set<DateComponents> = []
+    var showNavigation: Bool = true
+
+    /// 연도/월 피커를 표시할 VC (sheet present용)
+    weak var presenterViewController: UIViewController?
+
+    private let cal = Calendar.current
+    private let weekdayTitles = ["일", "월", "화", "수", "목", "금", "토"]
+    private let weekdayColor = UIColor(red: 0.235, green: 0.235, blue: 0.263, alpha: 0.3)
+
+    // MARK: - UI Components
+
+    private let containerStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 0
+        return stack
+    }()
+
+    private let headerStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        return stack
+    }()
+
+    private lazy var monthYearButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.imagePlacement = .trailing
+        config.imagePadding = 4
+        config.image = UIImage(.forward)?
+            .withConfiguration(UIImage.SymbolConfiguration(pointSize: 15, weight: .bold))
+        config.baseForegroundColor = .label
+        config.imageColorTransformer = UIConfigurationColorTransformer { _ in
+            UIColor(named: "yellow0") ?? .systemYellow
+        }
+        let button = UIButton(configuration: config)
+        button.addTarget(self, action: #selector(monthYearTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var leftButton: UIButton = {
+        let button = UIButton(type: .system)
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        button.setImage(UIImage(.back)?.withConfiguration(config), for: .normal)
+        button.tintColor = UIColor(named: "yellow0")
+        button.addTarget(self, action: #selector(prevMonth), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var rightButton: UIButton = {
+        let button = UIButton(type: .system)
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        button.setImage(UIImage(.forward)?.withConfiguration(config), for: .normal)
+        button.tintColor = UIColor(named: "yellow0")
+        button.addTarget(self, action: #selector(nextMonth), for: .touchUpInside)
+        return button
+    }()
+
+    private let weekdayStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        return stack
+    }()
+
+    private let dayGridStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 7
+        return stack
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupHierarchy()
+        setupLayout()
+        setupWeekdayRow()
+        setupSwipeGesture()
+        reloadCalendar()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public
+
+    func configure(readDates: Set<DateComponents>) {
+        guard self.readDates != readDates else { return }
+        self.readDates = readDates
+        reloadCalendar()
+    }
+}
+
+// MARK: - Setup
+
+private extension ReadingLogCalendarUIView {
+
+    func setupHierarchy() {
+        addSubview(containerStack)
+
+        // Header
+        let navStack = UIStackView(arrangedSubviews: [leftButton, rightButton])
+        navStack.axis = .horizontal
+        navStack.spacing = 28
+
+        let navContainer = UIView()
+        navContainer.addSubview(navStack)
+        navStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            navStack.topAnchor.constraint(equalTo: navContainer.topAnchor, constant: 7),
+            navStack.trailingAnchor.constraint(equalTo: navContainer.trailingAnchor, constant: -16),
+            navStack.bottomAnchor.constraint(equalTo: navContainer.bottomAnchor, constant: -9)
+        ])
+
+        let spacer = UIView()
+        headerStack.addArrangedSubview(monthYearButton)
+        headerStack.addArrangedSubview(spacer)
+        headerStack.addArrangedSubview(navContainer)
+
+        navContainer.isHidden = !showNavigation
+
+        containerStack.addArrangedSubview(headerStack)
+        containerStack.addArrangedSubview(weekdayStack)
+        containerStack.addArrangedSubview(dayGridStack)
+
+        containerStack.setCustomSpacing(4, after: headerStack)    // 헤더 ↔ 요일
+        containerStack.setCustomSpacing(3, after: weekdayStack)   // 요일 ↔ 첫 날짜행
+    }
+
+    func setupLayout() {
+        containerStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            containerStack.topAnchor.constraint(equalTo: topAnchor),
+            containerStack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerStack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            containerStack.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    func setupWeekdayRow() {
+        for title in weekdayTitles {
+            let label = UILabel()
+            label.text = title
+            label.font = .systemFont(ofSize: 13, weight: .semibold)
+            label.textColor = weekdayColor
+            label.textAlignment = .center
+            weekdayStack.addArrangedSubview(label)
+        }
+    }
+
+    func setupSwipeGesture() {
+        guard showNavigation else { return }
+        let swipe = UIPanGestureRecognizer(target: self, action: #selector(handleSwipe(_:)))
+        dayGridStack.addGestureRecognizer(swipe)
+    }
+}
+
+// MARK: - Calendar Logic
+
+private extension ReadingLogCalendarUIView {
+
+    func reloadCalendar() {
+        updateHeader()
+        reloadDays()
+    }
+
+    func updateHeader() {
+        var config = monthYearButton.configuration ?? .plain()
+        var attr = AttributeContainer()
+        attr.font = UIFont.title3Emphasized
+        config.attributedTitle = AttributedString(displayedMonth.formatted(monthYearFormatStyle), attributes: attr)
+        monthYearButton.configuration = config
+    }
+
+    func reloadDays() {
+        dayGridStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        let days = makeDays()
+        var index = 0
+
+        // 최대 6주 (행)
+        while index < days.count {
+            let rowStack = UIStackView()
+            rowStack.axis = .horizontal
+            rowStack.distribution = .fillEqually
+            rowStack.spacing = 0
+
+            for _ in 0..<7 {
+                if index < days.count {
+                    let day = days[index]
+                    let cell = makeDayCell(day)
+                    rowStack.addArrangedSubview(cell)
+                    index += 1
+                } else {
+                    rowStack.addArrangedSubview(makeEmptyCell())
+                }
+            }
+
+            dayGridStack.addArrangedSubview(rowStack)
+        }
+    }
+
+    func makeDayCell(_ day: Int) -> UIView {
+        let container = UIView()
+        container.heightAnchor.constraint(equalToConstant: 44).isActive = true
+
+        guard day > 0 else { return container }
+
+        let isToday = isTodayDay(day)
+        let isRead = isReadDay(day)
+
+        // 원형 배경
+        let circle = UIView()
+        circle.layer.cornerRadius = 22
+        circle.clipsToBounds = true
+        if isToday {
+            circle.backgroundColor = UIColor(named: "yellow0")
+        } else if isRead {
+            circle.backgroundColor = UIColor(named: "yellow0")?.withAlphaComponent(0.12)
+        }
+
+        // 숫자 라벨
+        let label = UILabel()
+        label.text = "\(day)"
+        label.font = .systemFont(ofSize: 20, weight: .regular)
+        label.textAlignment = .center
+        if isToday {
+            label.textColor = .white
+        } else if isRead {
+            label.textColor = UIColor(named: "yellow0")
+        } else {
+            label.textColor = .label
+        }
+
+        container.addSubview(circle)
+        container.addSubview(label)
+
+        circle.translatesAutoresizingMaskIntoConstraints = false
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            circle.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            circle.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            circle.widthAnchor.constraint(equalToConstant: 44),
+            circle.heightAnchor.constraint(equalToConstant: 44),
+            label.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: container.centerYAnchor)
+        ])
+
+        return container
+    }
+
+    func makeEmptyCell() -> UIView {
+        let view = UIView()
+        view.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        return view
+    }
+
+    // MARK: - Date Helpers
+
+    func makeDays() -> [Int] {
+        guard let range = cal.range(of: .day, in: .month, for: displayedMonth) else { return [] }
+        let firstWeekday = cal.component(.weekday, from: startOfMonth()) - 1
+        return Array(repeating: 0, count: firstWeekday) + Array(1...range.count)
+    }
+
+    func startOfMonth() -> Date {
+        cal.date(from: cal.dateComponents([.year, .month], from: displayedMonth)) ?? displayedMonth
+    }
+
+    func isTodayDay(_ day: Int) -> Bool {
+        let today = Date()
+        return cal.component(.day, from: today) == day &&
+               cal.isDate(today, equalTo: displayedMonth, toGranularity: .month)
+    }
+
+    func isReadDay(_ day: Int) -> Bool {
+        let components = DateComponents(
+            year: cal.component(.year, from: displayedMonth),
+            month: cal.component(.month, from: displayedMonth),
+            day: day
+        )
+        return readDates.contains(components)
+    }
+
+    func changeMonth(by value: Int) {
+        guard let newMonth = cal.date(byAdding: .month, value: value, to: displayedMonth) else { return }
+        displayedMonth = newMonth
+        UIView.animate(withDuration: 0.2) {
+            self.reloadCalendar()
+            self.layoutIfNeeded()
+        }
+    }
+}
+
+// MARK: - Actions
+
+private extension ReadingLogCalendarUIView {
+
+    @objc func prevMonth() { changeMonth(by: -1) }
+    @objc func nextMonth() { changeMonth(by: 1) }
+
+    @objc func monthYearTapped() {
+        let picker = MonthYearPickerViewController(
+            selectedDate: displayedMonth
+        ) { [weak self] newDate in
+            self?.displayedMonth = newDate
+            self?.reloadCalendar()
+        }
+        if let sheet = picker.sheetPresentationController {
+            sheet.detents = [.custom { _ in 280 }]
+        }
+        presenterViewController?.present(picker, animated: true)
+    }
+
+    @objc func handleSwipe(_ gesture: UIPanGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        let velocity = gesture.translation(in: dayGridStack).x
+        if velocity < -50 { changeMonth(by: 1) }
+        else if velocity > 50 { changeMonth(by: -1) }
+    }
+}
+
+// MARK: - MonthYearPickerViewController
+
+final class MonthYearPickerViewController: UIViewController {
+
+    private var selectedYear: Int
+    private var selectedMonth: Int
+    private let years: [Int]
+    private let onDateSelected: (Date) -> Void
+
+    private let pickerView = UIPickerView()
+
+    init(selectedDate: Date, onDateSelected: @escaping (Date) -> Void) {
+        let cal = Calendar.current
+        self.selectedYear = cal.component(.year, from: selectedDate)
+        self.selectedMonth = cal.component(.month, from: selectedDate)
+        self.years = Array((selectedYear - 5)...(selectedYear + 5))
+        self.onDateSelected = onDateSelected
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupUI()
+        selectCurrentDate()
+    }
+
+    private func setupUI() {
+        let doneButton = UIButton(type: .system)
+        doneButton.setTitle("완료", for: .normal)
+        doneButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        doneButton.tintColor = UIColor(named: "yellow0")
+        doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+
+        pickerView.dataSource = self
+        pickerView.delegate = self
+
+        view.addSubview(doneButton)
+        view.addSubview(pickerView)
+
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+        pickerView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            doneButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 16),
+            doneButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            pickerView.topAnchor.constraint(equalTo: doneButton.bottomAnchor, constant: 8),
+            pickerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            pickerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pickerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func selectCurrentDate() {
+        if let yearIndex = years.firstIndex(of: selectedYear) {
+            pickerView.selectRow(yearIndex, inComponent: 0, animated: false)
+        }
+        pickerView.selectRow(selectedMonth - 1, inComponent: 1, animated: false)
+    }
+
+    @objc private func doneTapped() {
+        var components = DateComponents()
+        components.year = selectedYear
+        components.month = selectedMonth
+        components.day = 1
+        if let date = Calendar.current.date(from: components) {
+            onDateSelected(date)
+        }
+        dismiss(animated: true)
+    }
+}
+
+// MARK: - UIPickerViewDataSource & Delegate
+
+extension MonthYearPickerViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+
+    func numberOfComponents(in pickerView: UIPickerView) -> Int { 2 }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        component == 0 ? years.count : 12
+    }
+
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        component == 0 ? "\(years[row])년" : "\(row + 1)월"
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        if component == 0 { selectedYear = years[row] }
+        else { selectedMonth = row + 1 }
+    }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// MARK: - SwiftUI Version
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 struct ReadingLogCalendar: View {
 
@@ -107,10 +550,7 @@ struct ReadingLogCalendar: View {
     // MARK: - Helpers
 
     private var monthYearString: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM yyyy"
-        formatter.locale = Locale(identifier: "en_US")
-        return formatter.string(from: displayedMonth)
+        displayedMonth.formatted(monthYearFormatStyle)
     }
 
     private func makeDays() -> [Int] {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
@@ -22,6 +22,21 @@ final class ReadingLogCalendarUIView: UIView {
     /// 연도/월 피커를 표시할 VC (sheet present용)
     weak var presenterViewController: UIViewController?
 
+    private lazy var monthYearPicker: MonthYearPickerViewController = {
+        let picker = MonthYearPickerViewController(
+            selectedDate: displayedMonth
+        ) { [weak self] newDate in
+            self?.displayedMonth = newDate
+            self?.reloadCalendar()
+        }
+        picker.isModalInPresentation = true
+        if let sheet = picker.sheetPresentationController {
+            sheet.detents = [.custom { _ in 280 }]
+            sheet.prefersGrabberVisible = true
+        }
+        return picker
+    }()
+
     private let cal = Calendar.current
     private let weekdayTitles = ["일", "월", "화", "수", "목", "금", "토"]
     private let weekdayColor = UIColor(red: 0.235, green: 0.235, blue: 0.263, alpha: 0.3)
@@ -323,16 +338,8 @@ private extension ReadingLogCalendarUIView {
     @objc func nextMonth() { changeMonth(by: 1) }
 
     @objc func monthYearTapped() {
-        let picker = MonthYearPickerViewController(
-            selectedDate: displayedMonth
-        ) { [weak self] newDate in
-            self?.displayedMonth = newDate
-            self?.reloadCalendar()
-        }
-        if let sheet = picker.sheetPresentationController {
-            sheet.detents = [.custom { _ in 280 }]
-        }
-        presenterViewController?.present(picker, animated: true)
+        monthYearPicker.updateSelectedDate(displayedMonth)
+        presenterViewController?.present(monthYearPicker, animated: true)
     }
 
     @objc func handleSwipe(_ gesture: UIPanGestureRecognizer) {
@@ -350,6 +357,8 @@ final class MonthYearPickerViewController: UIViewController {
     private var selectedYear: Int
     private var selectedMonth: Int
     private let years: [Int]
+    private let yearTitles: [String]
+    private let monthTitles: [String]
     private let onDateSelected: (Date) -> Void
 
     private let pickerView = UIPickerView()
@@ -359,6 +368,8 @@ final class MonthYearPickerViewController: UIViewController {
         self.selectedYear = cal.component(.year, from: selectedDate)
         self.selectedMonth = cal.component(.month, from: selectedDate)
         self.years = Array((selectedYear - 5)...(selectedYear + 5))
+        self.yearTitles = years.map { "\($0)년" }
+        self.monthTitles = (1...12).map { "\($0)월" }
         self.onDateSelected = onDateSelected
         super.init(nibName: nil, bundle: nil)
     }
@@ -373,6 +384,15 @@ final class MonthYearPickerViewController: UIViewController {
         view.backgroundColor = .systemBackground
         setupUI()
         selectCurrentDate()
+    }
+
+    func updateSelectedDate(_ date: Date) {
+        let cal = Calendar.current
+        selectedYear = cal.component(.year, from: date)
+        selectedMonth = cal.component(.month, from: date)
+        if isViewLoaded {
+            selectCurrentDate()
+        }
     }
 
     private func setupUI() {
@@ -429,8 +449,12 @@ extension MonthYearPickerViewController: UIPickerViewDataSource, UIPickerViewDel
         component == 0 ? years.count : 12
     }
 
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        component == 0 ? "\(years[row])년" : "\(row + 1)월"
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let label = (view as? UILabel) ?? UILabel()
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 20, weight: .regular)
+        label.text = component == 0 ? yearTitles[row] : monthTitles[row]
+        return label
     }
 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingTimeFormatter.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingTimeFormatter.swift
@@ -1,0 +1,42 @@
+//
+//  ReadingTimeFormatter.swift
+//  LivingStory-iOS
+//
+//  Created by Demian Yoo on 2/22/26.
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//  ⏱ 독서 시간 포맷터
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  사용법:
+//  ```swift
+//  let text = ReadingTimeFormatter.format(totalSeconds: 3661)
+//  // → "1시간 1분 1초"
+//  ```
+//
+
+import Foundation
+
+enum ReadingTimeFormatter {
+
+    /// 초 단위를 "X시간 Y분 Z초" 형식으로 변환
+    static func format(totalSeconds: Int) -> String {
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        var parts: [String] = []
+
+        if hours > 0 {
+            parts.append("\(hours)\(StringLiterals.My.hourUnit)")
+        }
+        if minutes > 0 {
+            parts.append("\(minutes)\(StringLiterals.My.minuteUnit)")
+        }
+        if seconds > 0 || parts.isEmpty {
+            parts.append("\(seconds)\(StringLiterals.My.secondUnit)")
+        }
+
+        return parts.joined(separator: " ")
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/StatCardView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/StatCardView.swift
@@ -1,0 +1,153 @@
+//
+//  StatCardView.swift
+//  LivingStory-iOS
+//
+//  Created by Demian Yoo on 2/22/26.
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//  📊 통계 카드 컴포넌트 (UIKit)
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  SwiftUI 버전: StatCard (StatisticsView.swift 내 정의)
+//
+//  사용법:
+//  ```swift
+//  let card = StatCardView()
+//  card.configure(icon: .calendar, title: "이번 달 읽은 책 수", value: "3권")
+//  ```
+//
+
+import UIKit
+
+// MARK: - UIKit Version
+
+final class StatCardView: UIView {
+
+    // MARK: - UI Components
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.tintColor = .label
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .subheadlineRegular
+        label.textColor = .label
+        return label
+    }()
+
+    private let valueLabel: UILabel = {
+        let label = UILabel()
+        label.font = .subheadlineEmphasized
+        label.textColor = .label
+        return label
+    }()
+
+    private let contentStack = UIStackView()
+    private var isLayoutReady = false
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupStyle()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public
+
+    /// 세로 레이아웃 (좁은 카드): 아이콘 + 세로(타이틀, 값)
+    func configure(icon: SymbolLiterals, title: String, value: String) {
+        if !isLayoutReady {
+            setupNarrowLayout()
+            isLayoutReady = true
+        }
+        iconImageView.image = UIImage(icon)
+        titleLabel.text = title
+        valueLabel.text = value
+    }
+
+    /// 가로 레이아웃 (넓은 카드): 아이콘 + 타이틀 ... 값
+    func configureWide(icon: SymbolLiterals, title: String, value: String) {
+        if !isLayoutReady {
+            setupWideLayout()
+            isLayoutReady = true
+        }
+        iconImageView.image = UIImage(icon)
+        titleLabel.text = title
+        valueLabel.text = value
+    }
+}
+
+// MARK: - Setup
+
+private extension StatCardView {
+
+    func setupStyle() {
+        backgroundColor = .white
+        layer.cornerRadius = 14
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.08
+        layer.shadowRadius = 4
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+    }
+
+    /// 좁은 카드: 각 요소 개별 배치
+    func setupNarrowLayout() {
+        addSubview(iconImageView)
+        addSubview(titleLabel)
+        addSubview(valueLabel)
+
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            // 아이콘
+            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),    // 왼쪽
+            iconImageView.topAnchor.constraint(equalTo: topAnchor, constant: 12),             // 위
+
+            // 타이틀 (예: "총 읽은 책 수")
+            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 8),  // 아이콘↔타이틀
+            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 12),                // 위
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),     // 오른쪽
+
+            // 값 (예: "95권")
+            valueLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),            // 타이틀과 왼쪽 정렬
+            valueLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 6),   // 타이틀↔값
+            valueLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),         // 아래
+        ])
+    }
+
+    /// 넓은 카드: icon + title + spacer + value
+    func setupWideLayout() {
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        contentStack.axis = .horizontal
+        contentStack.alignment = .center
+        contentStack.spacing = 0
+        contentStack.addArrangedSubview(iconImageView)
+        contentStack.addArrangedSubview(titleLabel)
+        contentStack.addArrangedSubview(spacer)
+        contentStack.addArrangedSubview(valueLabel)
+
+        contentStack.setCustomSpacing(8, after: iconImageView)  // 아이콘↔타이틀만 8
+
+        addSubview(contentStack)
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            contentStack.topAnchor.constraint(equalTo: topAnchor, constant: 14),
+            contentStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            contentStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -14)
+        ])
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -82,5 +82,12 @@ enum StringLiterals {
 
     enum My {
         static let title = "마이"
+        static let monthlyBookCount = "이번 달 읽은 책 수"
+        static let totalBookCount = "총 읽은 책 수"
+        static let totalReadingTime = "총 읽은 시간"
+        static let bookUnit = "권"
+        static let hourUnit = "시간"
+        static let minuteUnit = "분"
+        static let secondUnit = "초"
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
@@ -72,6 +72,12 @@ enum SymbolLiterals: String {
     case error = "xmark.circle.fill"
     case info = "info.circle.fill"
 
+    // MARK: - Statistics
+
+    case calendar = "calendar"
+    case books = "books.vertical.fill"
+    case clock = "clock"
+
     // MARK: - Reading
 
     case play = "play.fill"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Persistence/Extensions/ReadingSessionEntity+Extensions.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Persistence/Extensions/ReadingSessionEntity+Extensions.swift
@@ -17,7 +17,7 @@ extension ReadingSessionEntity {
             id: id ?? UUID(),
             startTime: startTime ?? Date(),
             endTime: endTime,
-            durationMinutes: Int(duration / 60),
+            durationSeconds: Int(duration),
             bookProfile: book?.toProfile() ?? BookProfileModel.mock,
             musicCategory: musicCategory.flatMap { MusicCategory(rawValue: $0) },
             lighting: LightingConfig(

--- a/LivingStory-iOS/LivingStory-iOS/Core/Persistence/Repositories/ReadingSessionRepository.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Persistence/Repositories/ReadingSessionRepository.swift
@@ -29,7 +29,7 @@ final class ReadingSessionRepository: ReadingSessionRepositoryProtocol {
         entity.id = session.id
         entity.startTime = session.startTime
         entity.endTime = session.endTime
-        entity.duration = Double(session.durationMinutes * 60)
+        entity.duration = Double(session.durationSeconds)
         entity.musicCategory = session.musicCategory?.rawValue
         entity.lightingHue = Int16(session.lighting.hue)
         entity.lightingSaturation = Int16(session.lighting.saturation)
@@ -99,25 +99,29 @@ final class ReadingSessionRepository: ReadingSessionRepositoryProtocol {
         let now = Date()
         let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now))!
         let endOfMonth = calendar.date(byAdding: .month, value: 1, to: startOfMonth)!
-        
+
         let request = ReadingSessionEntity.fetchRequest()
         request.predicate = NSPredicate(
             format: "startTime >= %@ AND startTime < %@",
             startOfMonth as NSDate,
             endOfMonth as NSDate
         )
-        return try context.fetch(request).count
+        let sessions = try context.fetch(request)
+        let uniqueISBNs = Set(sessions.compactMap { $0.book?.isbn })
+        return uniqueISBNs.count
     }
-    
+
     func fetchTotalBookCount() throws -> Int {
         let request = ReadingSessionEntity.fetchRequest()
-        return try context.fetch(request).count
+        let sessions = try context.fetch(request)
+        let uniqueISBNs = Set(sessions.compactMap { $0.book?.isbn })
+        return uniqueISBNs.count
     }
     
-    func fetchTotalMinutes() throws -> Int {
+    func fetchTotalSeconds() throws -> Int {
         let request = ReadingSessionEntity.fetchRequest()
         let sessions = try context.fetch(request)
-        return sessions.reduce(0) { $0 + Int($1.duration / 60) }
+        return sessions.reduce(0) { $0 + Int($1.duration) }
     }
     
     func fetchReadDates() throws -> Set<DateComponents> {
@@ -126,7 +130,11 @@ final class ReadingSessionRepository: ReadingSessionRepositoryProtocol {
         let calendar = Calendar.current
         let components = sessions.compactMap { session -> DateComponents? in
             guard let startTime = session.startTime else { return nil }
-            return calendar.dateComponents([.year, .month, .day], from: startTime)
+            return DateComponents(
+                year: calendar.component(.year, from: startTime),
+                month: calendar.component(.month, from: startTime),
+                day: calendar.component(.day, from: startTime)
+            )
         }
         return Set(components)
     }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Protocols/ReadingSessionRepositoryProtocol.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Protocols/ReadingSessionRepositoryProtocol.swift
@@ -18,6 +18,6 @@ protocol ReadingSessionRepositoryProtocol {
     func fetchTodaySessions() throws -> [ReadingSessionProfile]
     func fetchMonthlyBookCount() throws -> Int
     func fetchTotalBookCount() throws -> Int
-    func fetchTotalMinutes() throws -> Int
+    func fetchTotalSeconds() throws -> Int
     func fetchReadDates() throws -> Set<DateComponents>
 }

--- a/LivingStory-iOS/LivingStory-iOS/Model/ReadingSessionProfile.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Model/ReadingSessionProfile.swift
@@ -11,7 +11,7 @@ struct ReadingSessionProfile: Sendable {
     let id: UUID
     let startTime: Date
     let endTime: Date?
-    let durationMinutes: Int
+    let durationSeconds: Int
     let bookProfile: BookProfileModel
     let musicCategory: MusicCategory?
     let lighting: LightingConfig
@@ -27,7 +27,7 @@ extension ReadingSessionProfile {
         id: UUID(),
         startTime: Calendar.current.date(byAdding: .minute, value: -30, to: Date())!,
         endTime: Date(),
-        durationMinutes: 30,
+        durationSeconds: 1800,
         bookProfile: .mock,
         musicCategory: .calmPiano,
         lighting: LightingConfig(hue: 40, saturation: 60, brightness: 80),
@@ -42,7 +42,7 @@ extension ReadingSessionProfile {
             id: UUID(),
             startTime: Calendar.current.date(byAdding: .hour, value: -3, to: Date())!,
             endTime: Calendar.current.date(byAdding: .hour, value: -2, to: Date())!,
-            durationMinutes: 60,
+            durationSeconds: 3600,
             bookProfile: .mockISBN,
             musicCategory: .nature,
             lighting: LightingConfig(hue: 200, saturation: 40, brightness: 70),

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/My/MyViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/My/MyViewController.swift
@@ -12,6 +12,7 @@ final class MyViewController: UIViewController {
     // MARK: - Properties
 
     weak var coordinator: AppCoordinator?
+    private let repository: ReadingSessionRepositoryProtocol = ReadingSessionRepository()
 
     // MARK: - UI Components
 
@@ -25,6 +26,25 @@ final class MyViewController: UIViewController {
         return button
     }()
 
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        return stack
+    }()
+
+    private let calendarView = ReadingLogCalendarUIView()
+
+    private let monthlyCard = StatCardView()
+    private let totalBookCard = StatCardView()
+    private let totalTimeCard = StatCardView()
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
@@ -33,9 +53,15 @@ final class MyViewController: UIViewController {
         setupHierarchy()
         setupLayout()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configureCalendar()
+        configureStats()
+    }
 }
 
-// MARK: - Private Methods
+// MARK: - Setup
 
 private extension MyViewController {
 
@@ -55,17 +81,74 @@ private extension MyViewController {
 
     func setupHierarchy() {
         view.addSubview(radialGlowView)
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        // 통계 카드 컨테이너
+        let cardRow = UIStackView(arrangedSubviews: [monthlyCard, totalBookCard])
+        cardRow.axis = .horizontal
+        cardRow.spacing = 12
+        cardRow.distribution = .fillEqually
+
+        let statsContainer = UIStackView(arrangedSubviews: [cardRow, totalTimeCard])
+        statsContainer.axis = .vertical
+        statsContainer.spacing = 10  // cardRow ↔ totalTimeCard 간격
+
+        contentStack.addArrangedSubview(calendarView)
+        contentStack.addArrangedSubview(statsContainer)
+
+        contentStack.setCustomSpacing(34, after: calendarView)  // 캘린더 ↔ 스탯 컨테이너
     }
 
     func setupLayout() {
         radialGlowView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             radialGlowView.widthAnchor.constraint(equalToConstant: 589),
             radialGlowView.heightAnchor.constraint(equalToConstant: 610),
             radialGlowView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: -100),
-            radialGlowView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            radialGlowView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 25),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 20),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -20),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -32),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -40)
         ])
     }
-}
 
+    func configureCalendar() {
+        calendarView.presenterViewController = self
+        let readDates = (try? repository.fetchReadDates()) ?? []
+        calendarView.configure(readDates: readDates)
+    }
+
+    func configureStats() {
+        let monthlyCount = (try? repository.fetchMonthlyBookCount()) ?? 0
+        let totalCount = (try? repository.fetchTotalBookCount()) ?? 0
+
+        monthlyCard.configure(
+            icon: .calendar,
+            title: StringLiterals.My.monthlyBookCount,
+            value: "\(monthlyCount)\(StringLiterals.My.bookUnit)"
+        )
+        totalBookCard.configure(
+            icon: .books,
+            title: StringLiterals.My.totalBookCount,
+            value: "\(totalCount)\(StringLiterals.My.bookUnit)"
+        )
+        let totalSeconds = (try? repository.fetchTotalSeconds()) ?? 0
+        totalTimeCard.configureWide(
+            icon: .clock,
+            title: StringLiterals.My.totalReadingTime,
+            value: ReadingTimeFormatter.format(totalSeconds: totalSeconds)
+        )
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -128,13 +128,13 @@ final class ReadingViewModel {
         guard let startTime else { return }
 
         let endTime = Date()
-        let durationMinutes = Int(endTime.timeIntervalSince(startTime) / 60)
+        let durationSeconds = Int(endTime.timeIntervalSince(startTime))
 
         let session = ReadingSessionProfile(
             id: UUID(),
             startTime: startTime,
             endTime: endTime,
-            durationMinutes: durationMinutes,
+            durationSeconds: durationSeconds,
             bookProfile: book,
             musicCategory: musicCategory,
             lighting: lightingConfig ?? .default,
@@ -148,7 +148,7 @@ final class ReadingViewModel {
         do {
             try bookRepository.saveBook(book)
             try sessionRepository.saveSession(session, bookISBN: book.isbn)
-            print("[Session] 독서 기록 저장 - \(durationMinutes)분")
+            print("[Session] 독서 기록 저장 - \(durationSeconds)초")
         } catch {
             print("[Session] 저장 실패: \(error)")
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -48,12 +48,8 @@ struct StatisticsView: View {
     }
 
     private var totalTimeString: String {
-        let minutes = (try? repository.fetchTotalMinutes()) ?? 0
-        let hours = minutes / 60
-        let mins = minutes % 60
-        if hours > 0 && mins > 0 { return "\(hours)시간 \(mins)분" }
-        if hours > 0 { return "\(hours)시간" }
-        return "\(mins)분"
+        let totalSeconds = (try? repository.fetchTotalSeconds()) ?? 0
+        return ReadingTimeFormatter.format(totalSeconds: totalSeconds)
     }
 
     // MARK: - Subviews


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #37 

## 📝 Summary
마이 탭에 커스텀 캘린더 + 독서 통계 카드를 UIKit으로 구현했습니다. 독서 세션의 시간 기록을 분 단위에서 초 단위로 전환하여 정밀도를 높이고, DateComponents 정규화로 읽은 날짜 매칭 버그를 수정했습니다.

 ## 🏗 Architecture Decision (설계 의사결정)                                                                                                                                                                     
                                                                                                                                                                                                                 
  ### 1. UIKit 순수 구현 (UIHostingController 미사용)
  - **문제**: 마이 탭 루트 VC를 SwiftUI로 임베딩할지, UIKit으로 직접 구현할지
  - **대안 검토**: UIHostingController로 SwiftUI 뷰 임베드 (간편하나 UIKit navigation 제어 제한)
  - **선택**: UIKit 순수 구현 — UIStackView 기반 캘린더 + Auto Layout 통계 카드. 기존 Coordinator 패턴과 일관성 유지, UIKit navigation bar (large title) 직접 제어 가능

  ### 2. UIKit/SwiftUI 듀얼 컴포넌트 패턴
  - **문제**: ReadingLogCalendar가 SwiftUI로 이미 존재하나, 마이 탭은 UIKit 필요
  - **선택**: 동일 파일에 UIKit(`ReadingLogCalendarUIView`) + SwiftUI(`ReadingLogCalendar`) 공존 — PrimaryButton.swift 패턴 준수. StatCardView는 UIKit 전용 (SwiftUI StatCard는 이토 담당 파일에 별도 존재)

  ### 3. durationMinutes → durationSeconds 전환
  - **문제**: `Int(timeInterval / 60)`으로 분 단위 변환 시 초 정보 유실 (3분 45초 → 3분)
  - **선택**: 전체 데이터 흐름을 초 단위로 통일. ReadingSessionProfile → CoreData → Repository → Formatter 전 구간에서 초 기반 처리. ReadingTimeFormatter로 "X시간 Y분 Z초" 표시

  ### 4. DateComponents 정규화
  - **문제**: `Calendar.dateComponents(_:from:)`가 반환하는 DateComponents에 내부 프로퍼티(calendar, era 등)가 추가되어 `Set.contains()` 매칭 실패
  - **선택**: Repository와 캘린더 양쪽 모두 `DateComponents(year:month:day:)` 직접 생성으로 통일하여 Hashable 일관성 보장

## 🔨 What

 | 파일 | 역할 |
  |------|------|
  | `StatCardView.swift` | UIKit 통계 카드 컴포넌트 (narrow/wide 레이아웃) |
  | `ReadingTimeFormatter.swift` | 초 → "X시간 Y분 Z초" 포맷 변환 |
  
  | 파일 | 변경 내용 |
  |------|----------|
  | `ReadingLogCalendar.swift` | UIKit ReadingLogCalendarUIView + MonthYearPickerViewController 추가, Date.FormatStyle 전환, 데이터 동일 시 리빌드 스킵 |
  | `MyViewController.swift` | 플레이스홀더 → 캘린더 + 통계 카드 3개 연동, viewWillAppear 데이터 갱신 |
  | `StringLiterals.swift` | My enum 추가 (7개 문자열) |
  | `SymbolLiterals.swift` | Statistics 섹션 추가 (calendar, books, clock) |
  | `ReadingSessionProfile.swift` | durationMinutes → durationSeconds |
  | `ReadingSessionRepository.swift` | 초 단위 저장, 유니크 ISBN 카운팅, DateComponents 정규화 |
  | `ReadingSessionEntity+Extensions.swift` | toProfile() 초 단위 변환 |
  | `ReadingSessionRepositoryProtocol.swift` | fetchTotalMinutes → fetchTotalSeconds |
  | `ReadingViewModel.swift` | 초 단위 계산 및 저장 |
  | `StatisticsView.swift` | fetchTotalSeconds + ReadingTimeFormatter 호환 |
  
   ## 📸 Screenshots

  ### 마이 탭 — 캘린더 + 통계 카드
  | 기본 화면 |
  |----------|
  |<img width="300" height="700" alt="KakaoTalk_Photo_2026-02-22-03-10-44 001" src="https://github.com/user-attachments/assets/0929f0be-d74f-48c7-8fbe-668345746a83" />|
  
 ### 월 이동 + 날짜 선택

https://github.com/user-attachments/assets/969b011b-22cd-40a0-958a-fa7cd6664cf2


  ## 🔧 Troubleshooting (트러블슈팅)

  ### 1. DateComponents Set.contains() 매칭 실패
  - **원인**: `Calendar.dateComponents([.year, .month, .day], from:)` 반환값에 추가 프로퍼티가 포함되어 수동 생성 DateComponents와 hash 불일치
  - **해결**: 양쪽 모두 `DateComponents(year:month:day:)` 직접 생성으로 통일

  ### 2. StatCardView 제약 누적 (viewWillAppear 반복 호출)
  - **원인**: configure() 호출 시 매번 setupLayout() → NSLayoutConstraint.activate() 실행
  - **해결**: `isLayoutReady` 플래그로 레이아웃 1회만 설정, 이후 데이터만 업데이트

  ### 3. 초 단위 미표시
  - **원인**: `Int(timeInterval / 60)` 변환으로 초 정보 유실, CoreData에 항상 60배수로 저장
  - **해결**: 전체 파이프라인 durationSeconds로 통일, ReadingTimeFormatter로 시분초 표시

 ### 4. MonthYearPicker 휠 스크롤 시 렉 발생                                                                                                                                                                    
  - **원인**: 탭마다 새 VC 생성 + UIPickerView 초기 레이아웃 비용 + 시트 드래그 제스처와 피커 휠 제스처 충돌                                                                                                     
  - **해결**: lazy var로 VC 1회 생성 재사용, 문자열 캐싱(yearTitles/monthTitles), viewForRow 뷰 재활용, isModalInPresentation으로 제스처 충돌 방지

  ---

  ## 🔮 Future Work
  - AppCoordinator 탭별 분리 리팩토링 (PO-58, TOASTER-iOS 패턴 참조)
  - Repository 메인스레드 동기 fetch → async 전환 (데이터 증가 대비)
  - UIKit/SwiftUI 캘린더 공통 로직 CalendarDataSource 추출

## 👀 Review Notes

- `ReadingLogCalendarUIView` 날짜 셀은 viewWillAppear마다 remove → 재생성 구조. 데이터 동일 시 guard로 스킵하지만, 데이터 변경 시 전체 리빌드. 대량 세션 시 성능 확인 필요
  - StatisticsView/ResultView의 하드코딩 문자열은 이토 담당 파일이라 미변경
  - 기존 CoreData 데이터는 분*60으로 저장되어 초 표시 불가, 신규 세션부터 초 단위 정확 표시
