### PR TITLE
[Fix][PO-56] HomeKit 조명 제어 시 primaryHome 대신 조명 보유 집 우선 선택

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -48,9 +48,14 @@ final class HomeKitLightingController: NSObject, LightingControllable {
 
     func applyLighting(_ config: LightingConfig) async throws {
         let homes = try await ensureHomesLoaded()
-        guard let primaryHome = homes.first else {
+        guard !homes.isEmpty else {
             throw HomeKitLightingError.noHomesAvailable
         }
+
+        // 조명이 있는 집 우선, 없으면 primaryHome fallback
+        let primaryHome = homes.first(where: { !findLightServices(in: $0).isEmpty })
+            ?? homeManager.primaryHome
+            ?? homes.first!
 
         let lightServices = findLightServices(in: primaryHome)
         guard !lightServices.isEmpty else {


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #42 

## 📝 Summary
HomeKit에 여러 집이 등록된 환경에서 `primaryHome`에 조명이 없으면 조명 제어가 실패하는 버그 수정.

 ## 🔨 What
  - `HomeKitLightingController.applyLighting()` — 집 선택 로직 변경
    - Before: `homes.first` (첫 번째 집 = primaryHome, 조명 없을 수 있음)
    - After: 조명 서비스가 있는 집 우선 → primaryHome fallback → first fallback

  ## 🔧 Troubleshooting
  | 문제 | 원인 | 해결 |
  |------|------|------|
  | `제어 가능한 조명을 찾을 수 없습니다` | `homes.first`가 빈 집("나의 집") 반환 | `homes.first(where:)` 로 조명 보유 집 우선 선택 |

  ## 👀 Review Notes
  - HomeKit Accessory Simulator로 다중 Home 환경 재현하여 검증
  - Gemini → HSB 적용 → HAS 조명 값 변경 E2E 확인 완료