### PR TITLE
[PO-63] 1차 MVP 이후 팀 내부 배포 용 ( 테플 적용 전 )

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
@@ -23,69 +23,80 @@ import UIKit
 import SwiftUI
 
 // UIKit Extension
+//
+// UIFontMetrics.scaledFont(for:) 를 사용하면
+// 설정 → 디스플레이 → 텍스트 크기 변경 시 자동으로 폰트 크기가 조절됩니다.
 
 extension UIFont {
-    // MARK: LaregeTitle
-    static let largeTitleEmphasized: UIFont = .systemFont(ofSize: 34, weight: .bold)
-    
+
+    // MARK: Large Title
+    static let largeTitleEmphasized: UIFont = scaled(.largeTitle, size: 34, weight: .bold)
+
     // MARK: Title
-    static let title1Emphasized: UIFont = .systemFont(ofSize: 28, weight: .bold)
-    static let title2Emphasized: UIFont = .systemFont(ofSize: 22, weight: .bold)
-    static let title3Emphasized: UIFont = .systemFont(ofSize: 20, weight: .semibold)
-    
+    static let title1Emphasized: UIFont = scaled(.title1, size: 28, weight: .bold)
+    static let title2Emphasized: UIFont = scaled(.title2, size: 22, weight: .bold)
+    static let title3Emphasized: UIFont = scaled(.title3, size: 20, weight: .semibold)
+
     // MARK: Headline / Subheadline
-    static let headlineRegular: UIFont = .systemFont(ofSize: 17, weight: .semibold )
-    static let subheadlineRegular: UIFont = .systemFont(ofSize: 15, weight: .regular )
-    static let subheadlineEmphasized: UIFont = .systemFont(ofSize: 15, weight: .semibold )
-    
+    static let headlineRegular: UIFont = scaled(.headline, size: 17, weight: .semibold)
+    static let subheadlineRegular: UIFont = scaled(.subheadline, size: 15, weight: .regular)
+    static let subheadlineEmphasized: UIFont = scaled(.subheadline, size: 15, weight: .semibold)
+
     // MARK: Body
-    static let bodyRegular: UIFont = .systemFont(ofSize: 17, weight: .regular)
-    static let bodyMedium: UIFont = .systemFont(ofSize: 17, weight: .medium)
-    static let bodyEmphasized: UIFont = .systemFont(ofSize: 17, weight: .semibold)
-    
+    static let bodyRegular: UIFont = scaled(.body, size: 17, weight: .regular)
+    static let bodyMedium: UIFont = scaled(.body, size: 17, weight: .medium)
+    static let bodyEmphasized: UIFont = scaled(.body, size: 17, weight: .semibold)
+
     // MARK: Callout
-    static let calloutEmphasized: UIFont = .systemFont(ofSize: 16, weight: .semibold)
-    
+    static let calloutEmphasized: UIFont = scaled(.callout, size: 16, weight: .semibold)
+
     // MARK: Footnote
-    static let footnoteRegular: UIFont = .systemFont(ofSize: 13, weight: .regular)
-    static let footnoteEmphasized: UIFont = .systemFont(ofSize: 13, weight: .semibold)
-    
-    // MARK: 커스텀 폰트 헬퍼
-    // TODO: 이후 커스텀 폰트 추가시
-    // Enum 로우벨류로 스트링타입으로 하나 추가하고 static func로 커스텀 함수 만들기.
-    
+    static let footnoteRegular: UIFont = scaled(.footnote, size: 13, weight: .regular)
+    static let footnoteEmphasized: UIFont = scaled(.footnote, size: 13, weight: .semibold)
+
     // MARK: Button Title
-    static let buttonTitle: UIFont = .systemFont(ofSize: 17, weight: .medium)
+    static let buttonTitle: UIFont = scaled(.body, size: 17, weight: .medium)
+
+    // MARK: - Helper
+
+    private static func scaled(_ textStyle: UIFont.TextStyle, size: CGFloat, weight: UIFont.Weight) -> UIFont {
+        let base = UIFont.systemFont(ofSize: size, weight: weight)
+        return UIFontMetrics(forTextStyle: textStyle).scaledFont(for: base)
+    }
 }
 
 // SwiftUI Extension
+//
+// SwiftUI의 .body, .title2 등 빌트인 TextStyle은 Dynamic Type을 자동 지원합니다.
+// 여기서는 디자인 시스템의 weight를 유지하면서 TextStyle 기반으로 스케일링합니다.
 
 extension Font {
+
     // MARK: Large Title
-    static let largeTitleEmphasized: Font = .system(size: 34, weight: .bold)
-    
+    static let largeTitleEmphasized: Font = .system(.largeTitle, weight: .bold)
+
     // MARK: Title
-    static let title1Emphasized: Font = .system(size: 28, weight: .bold)
-    static let title2Emphasized: Font = .system(size: 22, weight: .bold)
-    static let title3Emphasized: Font = .system(size: 20, weight: .semibold)
-    
+    static let title1Emphasized: Font = .system(.title, weight: .bold)
+    static let title2Emphasized: Font = .system(.title2, weight: .bold)
+    static let title3Emphasized: Font = .system(.title3, weight: .semibold)
+
     // MARK: Headline / Subheadline
-    static let headlineRegular: Font = .system(size: 17, weight: .semibold)
-    static let subheadlineRegular: Font = .system(size: 15, weight: .regular)
-    static let subheadlineEmphasized: Font = .system(size: 15, weight: .semibold)
-    
+    static let headlineRegular: Font = .system(.headline, weight: .semibold)
+    static let subheadlineRegular: Font = .system(.subheadline, weight: .regular)
+    static let subheadlineEmphasized: Font = .system(.subheadline, weight: .semibold)
+
     // MARK: Body
-    static let bodyRegular: Font = .system(size: 17, weight: .regular)
-    static let bodyMedium: Font = .system(size: 17, weight: .medium)
-    static let bodyEmphasized: Font = .system(size: 17, weight: .semibold)
-    
+    static let bodyRegular: Font = .system(.body, weight: .regular)
+    static let bodyMedium: Font = .system(.body, weight: .medium)
+    static let bodyEmphasized: Font = .system(.body, weight: .semibold)
+
     // MARK: Callout
-    static let calloutEmphasized: Font = .system(size: 16, weight: .semibold)
-    
+    static let calloutEmphasized: Font = .system(.callout, weight: .semibold)
+
     // MARK: Footnote
-    static let footnoteRegular: Font = .system(size: 13, weight: .regular)
-    static let footnoteEmphasized: Font = .system(size: 13, weight: .semibold)
-    
+    static let footnoteRegular: Font = .system(.footnote, weight: .regular)
+    static let footnoteEmphasized: Font = .system(.footnote, weight: .semibold)
+
     // MARK: Button Title
-    static let buttonTitle: Font = .system(size: 17, weight: .medium)
+    static let buttonTitle: Font = .system(.body, weight: .medium)
 }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -73,7 +73,7 @@ enum StringLiterals {
         static let failed = "인식 실패"
         static let retry = "다시 시도"
         static let guideTitle = "책 뒷면의 바코드 스캔"
-        static let guideSubtitle = "정확한 책의 정보를 가져오기 위해, 읽으실 책의\n바코드를 스캔해주세요. 바코드는 주로 뒷면에\n위치해 있습니다."
+        static let guideSubtitle = "정확한 책의 정보를 가져오기 위해, 읽으실 책의 바코드를 스캔해주세요. 바코드는 주로 뒷면에 위치해 있습니다."
         static let cameraPermissionTitle = "카메라 권한 필요"
         static let cameraPermissionMessage = "바코드를 스캔하려면 카메라 접근 권한이 필요합니다."
         static let cancel = "취소"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -97,8 +97,18 @@ final class ReadingViewModel {
                 startTimer()
             }
         } catch {
-            errorMessage = error.localizedDescription
-            print("[Gemini] 오류: \(error)")
+            print("[Gemini] 오류: \(error) — 기본값으로 독서 진행")
+
+            // Gemini 실패 시 기본값으로 fallback
+            lightingConfig = .default
+            musicCategory = .calmPiano
+            conversations = []
+
+            isLightingReady = true
+            isMusicPlaying = true
+            state = .reading
+            startTime = Date()
+            startTimer()
         }
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerGuideView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerGuideView.swift
@@ -30,7 +30,7 @@ final class ScannerGuideView: UIView {
     private let subtitleLabel: UILabel = {
         let label = UILabel()
         label.text = StringLiterals.Scanner.guideSubtitle
-        label.font = .footnoteRegular
+        label.font = .subheadlineRegular
         label.textColor = UIColor(named: "gray30")
         label.numberOfLines = 0
         return label

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -52,12 +52,11 @@ final class HomeKitLightingController: NSObject, LightingControllable {
             throw HomeKitLightingError.noHomesAvailable
         }
 
-        // 조명이 있는 집 우선, 없으면 primaryHome fallback
-        let primaryHome = homes.first(where: { !findLightServices(in: $0).isEmpty })
-            ?? homeManager.primaryHome
-            ?? homes.first!
+        // 조명이 있는 집 우선, 없으면 첫 번째 집 fallback
+        let targetHome = homes.first(where: { !findLightServices(in: $0).isEmpty })
+            ?? homes[0]
 
-        let lightServices = findLightServices(in: primaryHome)
+        let lightServices = findLightServices(in: targetHome)
         guard !lightServices.isEmpty else {
             throw HomeKitLightingError.noLightsFound
         }


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #45 

## 📝 Summary
- 1차 UT(사용성 테스트) 배포 전 안정화 수정. Dynamic Type 지원, Gemini API 실패 대응, deprecated API 제거.

## 🔨 What

### 1. Dynamic Type 지원 (`FontLiterals.swift`)
  - UIKit: `systemFont(ofSize:)` → `UIFontMetrics.scaledFont(for:)` 전환
  - SwiftUI: `Font.system(size:)` → `Font.system(.textStyle)` 전환
  - 시스템 텍스트 크기 변경 시 앱 내 폰트가 자동으로 스케일링
  - 기존 호출 코드 (`.font(.bodyRegular)`) 변경 없이 적용

  ### 2. Gemini API 실패 시 fallback (`ReadingViewModel.swift`)
  - 429 Rate Limit 등 API 오류 시 "환경 세팅중..." 무한 대기 → 기본값으로 독서 진행
  - 기본 조명: `LightingConfig.default` (H40 S20 B80, 따뜻한 백색)
  - 기본 음악: `.calmPiano`
  - 대화 주제: 빈 배열 (Gemini 응답 없으므로)

  ### 3. deprecated API 제거 (`HomeKitLightingController.swift`)
  - `homeManager.primaryHome` (iOS 16.1 deprecated) 제거
  - 조명 보유 집 우선 → `homes[0]` fallback (빈 배열은 상단 guard에서 처리)

  ### 4. 스캐너 가이드 텍스트 수정
  - `StringLiterals.swift`: 강제 줄바꿈(`\n`) 제거 → 자연 줄바꿈
  - `ScannerGuideView.swift`: 폰트 `.footnoteRegular` → `.subheadlineRegular`

  ## 🔧 Troubleshooting

  | 문제 | 원인 | 해결 |
  |------|------|------|
  | 시스템 글자 크기 변경해도 앱 반영 안 됨 | 고정 크기 `systemFont(ofSize:)` 사용 | `UIFontMetrics` + `TextStyle` 기반으로 전환 |
  | Gemini 429 시 화면 멈춤 | catch에서 errorMessage만 설정, state 전환 없음 | 기본값 fallback + state → .reading 전환 |
  | Xcode deprecated 경고 | `primaryHome` iOS 16.1 deprecated | 제거, `homes[0]` fallback |

  ## 🔮 Future Work
  - Unit Test 기반 구축 (Repository, ViewModel, Service)
  - DI Container 도입
  - 기기 선택 기능: 사용자가 특정 조명/스피커를 지정하여 독서 환경 제어

## 👀 Review Notes
- `FontLiterals.swift` 변경만으로 앱 전체 Dynamic Type 적용 (다른 파일 수정 불필요)
- Gemini fallback 시 조명/음악은 기본값으로 동작하므로 UT 중 API 한도 초과해도 독서 플로우 중단 없음
- `homes[0]`은 `guard !homes.isEmpty` 이후이므로 안전