### PR TITLE
[PO-57] 하드코딩 문자열·SF Symbol을 StringLiterals·SymbolLiterals로 통합

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -41,6 +41,12 @@ enum StringLiterals {
         static let stopSettingButton = "환경 세팅 중지"
         static let stopReadingButton = "그만 읽기"
         static let stopReadingAlertMessage = "중단시, 세팅된 환경이 중단될 거에요."
+        static let conversationPrompt = "책에 대해 아이와 대화를 나눠보세요."
+        static let restartScan = "다른 책 스캔"
+        static let setupButton = "책 환경 세팅하기"
+        static let resultTitle = "읽은 책"
+        static let homeButton = "홈으로"
+        static func todayBookCount(_ count: Int) -> String { "오늘 \(count)권의 책을 읽었어요!" }
     }
 
     enum Book {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
@@ -80,6 +80,7 @@ enum SymbolLiterals: String {
 
     // MARK: - Reading
 
+    case musicNoteHouse = "music.note.house.fill"
     case play = "play.fill"
     case pause = "pause.fill"
     case stop = "stop.fill"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
@@ -19,7 +19,7 @@ struct BookProfileView: View {
                     height: geometry.size.height * 0.7
                 )
                 Spacer()
-                PrimaryButtonSwiftUI(title: "책 환경 세팅하기") {
+                PrimaryButtonSwiftUI(title: StringLiterals.Reading.setupButton) {
                     coordinator.showReading(book: book)
                 }
                 .padding(.horizontal, 20)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -62,7 +62,7 @@ struct ReadingView: View {
 
     private var statusContent: some View {
         VStack(spacing: 28) {
-            Image(systemName: viewModel.state == .setting ? "house.fill" : "music.note.house.fill")
+            Image(viewModel.state == .setting ? .home : .musicNoteHouse)
                 .resizable()
                 .scaledToFit()
                 .foregroundStyle(.white)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -15,7 +15,7 @@ struct ResultView: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
-                Text("오늘 \((try? repository.fetchTodaySessions().count) ?? 0)권의 책을 읽었어요!")
+                Text(StringLiterals.Reading.todayBookCount((try? repository.fetchTodaySessions().count) ?? 0))
                     .font(.title2Emphasized)
                     .padding(.top, 33)
 
@@ -23,9 +23,9 @@ struct ResultView: View {
                     .padding(.top, 33)
 
                 StatCard(
-                    icon: "calendar",
-                    title: "이번 달 읽은 책 수",
-                    value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)권",
+                    icon: SymbolLiterals.calendar.rawValue,
+                    title: StringLiterals.My.monthlyBookCount,
+                    value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.bookUnit)",
                     isWide: true
                 )
             }
@@ -33,13 +33,13 @@ struct ResultView: View {
 
             Spacer()
 
-            PrimaryButtonSwiftUI(title: "홈으로") {
+            PrimaryButtonSwiftUI(title: StringLiterals.Reading.homeButton) {
                 coordinator.popToHome()
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 20)
         }
-        .navigationTitle("읽은 책")
+        .navigationTitle(StringLiterals.Reading.resultTitle)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .background(

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -26,7 +26,7 @@ struct StopReadingView: View {
 
     private var conversationSection: some View {
         VStack(alignment: .leading, spacing: 24) {
-            Text("책에 대해 아이와 대화를 나눠보세요.")
+            Text(StringLiterals.Reading.conversationPrompt)
                 .font(.title2Emphasized)
             ScrollView {
                 VStack(spacing: 10) {
@@ -45,11 +45,11 @@ struct StopReadingView: View {
 
     private var buttonSection: some View {
         VStack(spacing: 14) {
-            PrimaryButtonSwiftUI(title: "다른 책 스캔", action: {
+            PrimaryButtonSwiftUI(title: StringLiterals.Reading.restartScan, action: {
                     coordinator.restartScanner()
                 })
                 .padding(.horizontal, 20)
-            WhiteButtonSwiftUI(title: "그만 읽기", action: {
+            WhiteButtonSwiftUI(title: StringLiterals.Reading.stopReadingButton, action: {
                     coordinator.showResult()
                 })
                 .padding(.horizontal, 20)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -34,14 +34,14 @@ struct StatisticsView: View {
                 .frame(width: 589, height: 610)
                 .offset(y: 150)
             )
-        .navigationTitle("마이")
+        .navigationTitle(StringLiterals.My.title)
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem {
                 Button {
                     // setting시트 열리는 로직
                 } label: {
-                    Image(systemName: "gearshape")
+                    Image(.settings)
                 }
             }
         }
@@ -57,10 +57,10 @@ struct StatisticsView: View {
     private var statsSection: some View {
             VStack(spacing: 12) {
                 HStack(spacing: 10) {
-                    StatCard(icon: "calendar", title: "이번 달 읽은 책 수", value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)권")
-                    StatCard(icon: "books.vertical.fill", title: "총 읽은 책 수", value: "\((try? repository.fetchTotalBookCount()) ?? 0)권")
+                    StatCard(icon: SymbolLiterals.calendar.rawValue, title: StringLiterals.My.monthlyBookCount, value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.bookUnit)")
+                    StatCard(icon: SymbolLiterals.books.rawValue, title: StringLiterals.My.totalBookCount, value: "\((try? repository.fetchTotalBookCount()) ?? 0)\(StringLiterals.My.bookUnit)")
                 }
-                StatCard(icon: "clock", title: "총 읽은 시간", value: totalTimeString, isWide: true)
+                StatCard(icon: SymbolLiterals.clock.rawValue, title: StringLiterals.My.totalReadingTime, value: totalTimeString, isWide: true)
                 Spacer()
             }
     }


### PR DESCRIPTION
- Closes #44

## 📝 Summary
- PO-54 PR 리뷰에서 데미안 코멘트 반영: 하드코딩된 문자열과 SF Symbol을 StringLiterals·SymbolLiterals로 통합

## 🔨 What

### 1. StringLiterals 추가 (`StringLiterals.swift`)
- `Reading` enum에 6개 문자열 추가: `conversationPrompt`, `restartScan`, `setupButton`, `resultTitle`, `homeButton`, `todayBookCount(_:)`

### 2. SymbolLiterals 추가 (`SymbolLiterals.swift`)
- `musicNoteHouse` 케이스 추가 (`"music.note.house.fill"`)

### 3. 뷰 파일 하드코딩 교체 (5개 파일)
| 파일 | 변경 내용 |
|------|----------|
| `StopReadingView.swift` | 한글 문자열 3개 → StringLiterals |
| `ResultView.swift` | 한글 문자열 + SF Symbol → StringLiterals·SymbolLiterals |
| `BookProfileView.swift` | 버튼 타이틀 → StringLiterals |
| `StatisticsView.swift` | SF Symbol + 한글 문자열 → SymbolLiterals·StringLiterals |
| `ReadingView.swift` | SF Symbol → SymbolLiterals (`Image(.home : .musicNoteHouse)`) |

## 👀 Review Notes
- 기능 변경 없음, 리터럴 참조 방식만 변경
- `SymbolLiterals` 패턴 활용: `Image(.symbolCase)` 형태로 통일
- `StatCard`는 `String` 파라미터이므로 `.rawValue` 사용