### PR TITLE
[PO-71] BookProfileView 디자인 수정 + 독서 플로우 네비게이션 정리

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9S8SHSW95K;
+				DEVELOPMENT_TEAM = 8FKM9FB4PH;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -319,7 +319,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS.ito";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -343,7 +343,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9S8SHSW95K;
+				DEVELOPMENT_TEAM = 8FKM9FB4PH;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -356,7 +356,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS.ito";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -55,7 +55,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
@@ -25,6 +25,17 @@ struct BookProfileView: View {
                 .padding(.horizontal, 20)
             }
         }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    coordinator.pop()
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundStyle(.gray)
+                }
+            }
+        }
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
@@ -37,7 +37,7 @@ private struct BookCoverSection: View {
     let height: CGFloat
 
     var body: some View {
-        ZStack(alignment: .bottom) {
+        ZStack(alignment: .top) {
             if let url = bookCoverImageURL {
                 AsyncImage(url: url) { phase in
                     switch phase {
@@ -57,10 +57,12 @@ private struct BookCoverSection: View {
                             .ignoresSafeArea(edges: .top)
                     }
                 }
+                .frame(height: height)
             } else {
                 Rectangle()
                     .fill(Color.gray)
                     .ignoresSafeArea(edges: .top)
+                    .frame(height: height)
             }
 
             LinearGradient(
@@ -69,16 +71,17 @@ private struct BookCoverSection: View {
                 endPoint: .top
             )
             .ignoresSafeArea(edges: .top)
+            .frame(height: height)
 
             VStack(alignment: .leading, spacing: 12) {
+                Spacer()
                 Text(title)
                     .font(.title2Emphasized)
                 Text(plot)
                     .font(.bodyRegular)
             }
             .padding(.horizontal, 20)
-            .padding(.bottom, 20)
+            .padding(.bottom, 40)
         }
-        .frame(height: height)
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/BookProfile/BookProfileView.swift
@@ -32,7 +32,7 @@ struct BookProfileView: View {
                     coordinator.pop()
                 } label: {
                     Image(systemName: "xmark")
-                        .foregroundStyle(.gray)
+                        .foregroundStyle(.black)
                 }
             }
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -25,8 +25,10 @@ struct ReadingView: View {
         }
         .navigationTitle(viewModel.book.bookTitle)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .background { pulseBackground }
         .preferredColorScheme(.dark)
+        .toolbarColorScheme(.dark, for: .navigationBar)
         .onAppear {
             withAnimation(
                 .easeInOut(duration: 2.5)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -20,6 +20,7 @@ struct StopReadingView: View {
         }
         .navigationTitle(bookTitle)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
     }
 
     // MARK: - Subviews


### PR DESCRIPTION
- Closes #51

## 📝 Summary
- BookProfileView 이미지/텍스트 가독성 개선 (엘레나 디자인 반영) + 독서 플로우 전체 네비게이션 바 정리

## 🔨 What

### 1. BookProfileView 디자인 수정
- `BookCoverSection` ZStack alignment `.bottom` → `.top` 변경
- 이미지·그라디언트에 `.frame(height:)` 명시
- 텍스트 영역에 `Spacer()` 추가로 하단 배치
- back button 숨김 + 우상단 X 닫기 버튼 추가

### 2. 독서 플로우 네비게이션 바 정리
| 화면 | 변경 |
|------|------|
| BookProfileView | back button → X 닫기 버튼 |
| ReadingView | back button 숨김 + `toolbarColorScheme(.dark)` |
| StopReadingView | back button 숨김 |
| ResultView | 이미 적용됨 |

## 📸 Screenshots
| After |<img width="300" alt="IMG_3942" src="https://github.com/user-attachments/assets/cb250ce9-df6a-408d-9c69-0e73ce36c353" />

## 👀 Review Notes
- ReadingView에 `toolbarColorScheme(.dark)` 추가 — 다크 배경에서 네비게이션 타이틀이 안 보이던 문제 해결
- 독서 플로우 진입 후 뒤로가기 불가, X 또는 버튼 액션으로만 이동