### PR TITLE
[PO-70] Gemini API 에러 시 Alert 표시 및 재시도 처리

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9S8SHSW95K;
+				DEVELOPMENT_TEAM = 8FKM9FB4PH;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -319,7 +319,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS.ito";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -343,7 +343,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9S8SHSW95K;
+				DEVELOPMENT_TEAM = 8FKM9FB4PH;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -356,7 +356,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS.ito";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -53,6 +53,20 @@ struct ReadingView: View {
                 Text(StringLiterals.Reading.stopReadingAlertMessage)
             }
         }
+        .alert(
+            viewModel.errorMessage ?? "",
+            isPresented: Binding(
+                get: { viewModel.state == .error },
+                set: { _ in }
+            )
+        ) {
+            Button("재시도", role: .cancel) {
+                Task { await viewModel.retry() }
+            }
+            Button("닫기", role: .destructive) {
+                coordinator.pop()
+            }
+        }
         .task {
             await viewModel.startSetup()
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ReadingState: Sendable {
     case setting
     case reading
+    case error
 }
 
 @MainActor
@@ -97,18 +98,9 @@ final class ReadingViewModel {
                 startTimer()
             }
         } catch {
-            print("[Gemini] 오류: \(error) — 기본값으로 독서 진행")
-
-            // Gemini 실패 시 기본값으로 fallback
-            lightingConfig = .default
-            musicCategory = .calmPiano
-            conversations = []
-
-            isLightingReady = true
-            isMusicPlaying = true
-            state = .reading
-            startTime = Date()
-            startTimer()
+            print("[Gemini] 오류: \(error)")
+            errorMessage = "환경세팅에 오류가 발생했어요!"
+            state = .error
         }
     }
 
@@ -155,6 +147,13 @@ final class ReadingViewModel {
         } catch {
             print("[Gemini] 세션 저장 실패: \(error)")
         }
+    }
+
+    func retry() async {
+        errorMessage = nil
+        hasStarted = false
+        state = .setting
+        await startSetup()
     }
 
     // MARK: - Private


### PR DESCRIPTION
- Closes #50

## 📝 Summary
- Gemini API 에러 발생 시 기본값 fallback 대신 에러 Alert를 표시하여 사용자가 재시도 또는 닫기를 선택할 수 있도록 변경

## 🔨 What

### 1. ReadingState `.error` 추가 (`ReadingViewModel.swift`)
- 기존: `.setting` / `.reading` 2개
- 변경: `.setting` / `.reading` / `.error` 3개

### 2. Gemini 에러 처리 변경 (`ReadingViewModel.swift`)
- **AS-IS**: catch → 기본값 fallback → 바로 `.reading` 진입 (사용자 모르게 넘어감)
- **TO-BE**: catch → `errorMessage` 설정 + `.error` 상태 전환 → Alert 표시
- `retry()` 메서드 추가: `hasStarted` 리셋 후 `startSetup()` 재호출

### 3. 에러 Alert (`ReadingView.swift`)
- `.error` 상태일 때 Alert 표시
- 메시지: "환경세팅에 오류가 발생했어요!"
- **재시도** 버튼 (cancel role) → `viewModel.retry()`
- **닫기** 버튼 (destructive role) → `coordinator.pop()` (BookProfileView로 복귀)

## 👀 Review Notes
- 에러 Alert UI는 시스템 기본 Alert 사용 (엘레나 디자인 확정 시 커스텀 UI로 교체 가능)
- 기존 fallback 로직 제거 — 에러 시 사용자 선택 없이 독서 진행하지 않음
- 재시도 횟수 제한 없음 (네트워크 복구 시 성공할 수 있으므로)