### PR TITLE
[Feat][#PO-72] HomeKit 기기 실시간 동기화 및 async/await 전환

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8FKM9FB4PH;
+				DEVELOPMENT_TEAM = 9S8SHSW95K;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -319,7 +319,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS.ito";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -343,7 +343,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8FKM9FB4PH;
+				DEVELOPMENT_TEAM = 9S8SHSW95K;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -356,7 +356,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS.ito";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.GMYoo.Naru-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -55,7 +55,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
@@ -52,6 +52,22 @@ final class HomeViewController: UIViewController {
         homeDataSource.configure(with: roomCollectionView)
         setupEmptyStateActions()
         bindHomeKit()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Task { await homeKitManager.refreshAllCharacteristics() }
+    }
+
+    @objc private func handleWillEnterForeground() {
+        Task { await homeKitManager.refreshAllCharacteristics() }
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -12,7 +12,7 @@ final class HomeKitManager: NSObject {
     // MARK: - Properties
 
     private let homeManager = HMHomeManager()
-    private var pendingUpdateWorkItem: DispatchWorkItem?
+    private var pendingUpdateTask: Task<Void, Never>?
 
     /// HomeKit에서 집 목록이 업데이트되면 호출되는 콜백
     var onHomesUpdated: (([HomeModel]) -> Void)?
@@ -34,24 +34,53 @@ final class HomeKitManager: NSObject {
             handleStatus(status)
         }
     }
+
+    /// 모든 구독 대상 특성의 최신 값을 HomeKit에서 읽어옴 (포그라운드 복귀 시 호출)
+    func refreshAllCharacteristics() async {
+        let subscribableTypes: Set<String> = [
+            HMCharacteristicTypePowerState,
+            HMCharacteristicTypeBrightness,
+            HMCharacteristicTypeVolume
+        ]
+
+        let characteristics = homeManager.homes
+            .flatMap(\.rooms)
+            .flatMap(\.accessories)
+            .flatMap(\.services)
+            .flatMap(\.characteristics)
+            .filter { subscribableTypes.contains($0.characteristicType) }
+
+        await withTaskGroup(of: Void.self) { group in
+            for characteristic in characteristics {
+                group.addTask {
+                    try? await characteristic.readValue()
+                }
+            }
+        }
+    }
 }
 
 extension HomeKitManager: HMHomeDelegate {
     
     func home(_ home: HMHome, didAdd accessory: HMAccessory) {
         accessory.delegate = self
-        enableNotifications(for: accessory)
-        
-        let homes = homeManager.homes.map { mapHome($0) }
-        DispatchQueue.main.async { [weak self] in
-            self?.onHomesUpdated?(homes)
+
+        Task {
+            await enableNotifications(for: accessory)
+
+            let homes = homeManager.homes.map { mapHome($0) }
+            await MainActor.run {
+                onHomesUpdated?(homes)
+            }
         }
     }
-    
+
     func home(_ home: HMHome, didRemove accessory: HMAccessory) {
-        let homes = homeManager.homes.map { mapHome($0)}
-        DispatchQueue.main.async { [weak self] in
-            self?.onHomesUpdated?(homes)
+        Task {
+            let homes = homeManager.homes.map { mapHome($0) }
+            await MainActor.run {
+                onHomesUpdated?(homes)
+            }
         }
     }
 }
@@ -77,20 +106,21 @@ private extension HomeKitManager {
 
     func handleStatus(_ status: HMHomeManagerAuthorizationStatus) {
         guard status.contains(.authorized) else {
-            DispatchQueue.main.async { [weak self] in
-                self?.onPermissionDenied?()
+            Task { @MainActor in
+                onPermissionDenied?()
             }
             return
         }
 
-        for home in homeManager.homes {
-            registerForNotifications(in: home)
-        }
+        Task {
+            for home in homeManager.homes {
+                await registerForNotifications(in: home)
+            }
 
-        let homes = homeManager.homes.map { mapHome($0) }
-      
-        DispatchQueue.main.async { [weak self] in
-            self?.onHomesUpdated?(homes)
+            let homes = homeManager.homes.map { mapHome($0) }
+            await MainActor.run {
+                onHomesUpdated?(homes)
+            }
         }
     }
 }
@@ -103,14 +133,13 @@ extension HomeKitManager: HMAccessoryDelegate {
     func accessory(_ accessory: HMAccessory, service: HMService,
                    didUpdateValueFor characteristic: HMCharacteristic) {
         // 디바운싱: 150ms 내 연속 변경을 최종 1회로 합침 (밝기 슬라이더 등)
-        pendingUpdateWorkItem?.cancel()
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            let homes = self.homeManager.homes.map { self.mapHome($0) }
-            self.onHomesUpdated?(homes)
+        pendingUpdateTask?.cancel()
+        pendingUpdateTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            let homes = homeManager.homes.map { mapHome($0) }
+            onHomesUpdated?(homes)
         }
-        pendingUpdateWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: workItem)
     }
 }
 
@@ -121,18 +150,18 @@ private extension HomeKitManager {
     // MARK: - Notification Registration
 
     /// 집 안 모든 액세서리에 delegate 설정 + 특성 변경 알림 구독
-    func registerForNotifications(in home: HMHome) {
+    func registerForNotifications(in home: HMHome) async {
         home.delegate = self
         for room in home.rooms {
             for accessory in room.accessories {
                 accessory.delegate = self
-                enableNotifications(for: accessory)
+                await enableNotifications(for: accessory)
             }
         }
     }
 
     /// 특성 값 변경 이벤트 알림 활성화 (전원, 밝기, 볼륨)
-    func enableNotifications(for accessory: HMAccessory) {
+    func enableNotifications(for accessory: HMAccessory) async {
         let subscribableTypes: Set<String> = [
             HMCharacteristicTypePowerState,
             HMCharacteristicTypeBrightness,
@@ -142,10 +171,10 @@ private extension HomeKitManager {
             for characteristic in service.characteristics where
                 subscribableTypes.contains(characteristic.characteristicType) &&
                 characteristic.properties.contains(HMCharacteristicPropertySupportsEventNotification) {
-                characteristic.enableNotification(true) { error in
-                    if let error {
-                        print("[HomeKit] 알림 활성화 실패 (\(accessory.name)): \(error.localizedDescription)")
-                    }
+                do {
+                    try await characteristic.enableNotification(true)
+                } catch {
+                    print("[HomeKit] 알림 활성화 실패 (\(accessory.name)): \(error.localizedDescription)")
                 }
             }
         }

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -132,6 +132,7 @@ extension HomeKitManager: HMAccessoryDelegate {
     /// 액세서리의 특성 값이 변경되면 호출 (외부 앱, 자동화, 물리 제어 등)
     func accessory(_ accessory: HMAccessory, service: HMService,
                    didUpdateValueFor characteristic: HMCharacteristic) {
+        print("[HomeKit] 특성 변경 감지: \(accessory.name) - \(characteristic.characteristicType) = \(String(describing: characteristic.value))")
         // 디바운싱: 150ms 내 연속 변경을 최종 1회로 합침 (밝기 슬라이더 등)
         pendingUpdateTask?.cancel()
         pendingUpdateTask = Task { @MainActor in

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -36,6 +36,26 @@ final class HomeKitManager: NSObject {
     }
 }
 
+extension HomeKitManager: HMHomeDelegate {
+    
+    func home(_ home: HMHome, didAdd accessory: HMAccessory) {
+        accessory.delegate = self
+        enableNotifications(for: accessory)
+        
+        let homes = homeManager.homes.map { mapHome($0) }
+        DispatchQueue.main.async { [weak self] in
+            self?.onHomesUpdated?(homes)
+        }
+    }
+    
+    func home(_ home: HMHome, didRemove accessory: HMAccessory) {
+        let homes = homeManager.homes.map { mapHome($0)}
+        DispatchQueue.main.async { [weak self] in
+            self?.onHomesUpdated?(homes)
+        }
+    }
+}
+
 // MARK: - HMHomeManagerDelegate
 
 extension HomeKitManager: HMHomeManagerDelegate {
@@ -102,6 +122,7 @@ private extension HomeKitManager {
 
     /// 집 안 모든 액세서리에 delegate 설정 + 특성 변경 알림 구독
     func registerForNotifications(in home: HMHome) {
+        home.delegate = self
         for room in home.rooms {
             for accessory in room.accessories {
                 accessory.delegate = self


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #56 

## 📝 Summary
홈앱에서 기기 추가/삭제 시 나루앱에 실시간 반영되지 않던 문제를 해결하고, DispatchQueue 기반 코드를 async/await로 전환했습니다.

## 🏗 Architecture Decision (설계 의사결정)

  ### 1. DispatchQueue → Task + MainActor 전환
  - **문제**: `DispatchQueue.main.async`, `DispatchWorkItem` 등 레거시 동시성 패턴 사용 중
  - **대안 검토**: 기존 패턴 유지 — 동작에는 문제 없으나 Swift Concurrency와 혼용 시 데이터 레이스 위험
  - **선택**: `Task { @MainActor in }`, `MainActor.run`으로 전환. WWDC 2025 "Embracing Swift concurrency" 권장 패턴 적용

  ### 2. 디바운싱 — DispatchWorkItem vs Task.sleep
  - **문제**: 밝기 슬라이더 등 연속 변경 시 UI 갱신을 최종 1회로 합쳐야 함
  - **선택**: `Task.sleep(for: .milliseconds(150))` + `Task.isCancelled` 체크로 디바운싱 구현. DispatchWorkItem 완전 제거

  ### 3. readValue() 병렬 실행 — for문 vs TaskGroup
  - **문제**: 포그라운드 복귀 시 모든 특성의 최신 값을 읽어야 하는데, 순차 실행 시 기기 수에 비례하여 지연
  - **선택**: `flatMap`으로 5중 for문 평탄화 + `withTaskGroup`으로 모든 `readValue()` 병렬 실행

  ### 4. HMHomeDelegate / HMAccessoryDelegate 유지
  - **문제**: Delegate 패턴을 async로 대체할 수 있는지 검토
  - **선택**: Apple 공식 문서 상 Delegate 패턴의 async 대체 API 없음 → Delegate 유지하되 내부 구현만 모던화
| 파일 | 변경 내용 |
  |------|----------|
  | `HomeKitManager.swift` | `enableNotifications(for:)` completion handler → `async/await` 전환 |
  | `HomeKitManager.swift` | `registerForNotifications(in:)` sync → `async` 전환 |
  | `HomeKitManager.swift` | `handleStatus()` DispatchQueue → `Task` + `MainActor` 전환 |
  | `HomeKitManager.swift` | HMAccessoryDelegate 디바운싱 `DispatchWorkItem` → `Task` + `Task.sleep` 전환 |
  | `HomeKitManager.swift` | HMHomeDelegate `didAdd`/`didRemove` 내부 `DispatchQueue` → `Task` + `MainActor` 전환 |
  | `HomeKitManager.swift` | `refreshAllCharacteristics()` 추가 (`flatMap` + `TaskGroup` 병렬 `readValue`) |
  | `HomeViewController.swift` | `viewWillAppear`에서 `refreshAllCharacteristics()` 호출 (탭 전환 시 동기화) |
  | `HomeViewController.swift` | `willEnterForegroundNotification` 옵저버 등록 (포그라운드 복귀 시 동기화) |

  ## 🔧 Troubleshooting (트러블슈팅)

  ### 1. 시리로 조명 제어 시 앱에 실시간 반영 안 됨
  - **원인**: `enableNotification(true)` completion handler 방식에서 등록 실패 시 에러가 무시되고 있었음
  - **해결**: `try await enableNotification(true)`로 전환하여 에러 명시적 처리

  ### 2. 포그라운드 복귀 시 stale 값 표시
  - **원인**: 백그라운드 상태에서 HomeKit 특성 값 변경이 누적되어도 `readValue()` 호출이 없어 캐시된 값만 표시
  - **해결**: `viewWillAppear` + `willEnterForegroundNotification`에서 `refreshAllCharacteristics()` 호출

  ## 🔮 Future Work
  - 조명 특성(H/S/B) 순차 적용 시 이전 색상이 잠깐 보이는 문제 개선
  - 디버그 로그 정리

  ## 👀 Review Notes
  - `HomeKitManager` 내 `DispatchQueue` 사용이 전부 `Task`/`MainActor`로 대체됨 — 누락된 부분 없는지 확인
  - `refreshAllCharacteristics()`의 `TaskGroup` 병렬 실행 — 기기 수가 많을 때 성능 이슈 없는지 검토
  - 실기기에서 홈앱 기기 추가/삭제, 시리 조명 제어 시 실시간 반영 확인 완료