### PR TITLE
[Fix] [#PO-73] UI/UX 흐름 수정 (navigationTitle, 바텀시트 detent, 바코드 바운딩 박스)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -120,6 +120,8 @@ final class AppCoordinator: Coordinator {
         )
         let view = ReadingView(coordinator: self, viewModel: viewModel)
         let hostingVC = UIHostingController(rootView: view)
+        hostingVC.title = book.bookTitle
+        hostingVC.navigationItem.largeTitleDisplayMode = .never
         (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
@@ -339,6 +339,10 @@ private extension ReadingLogCalendarUIView {
 
     @objc func monthYearTapped() {
         monthYearPicker.updateSelectedDate(displayedMonth)
+        if let sheet = monthYearPicker.sheetPresentationController {
+            sheet.detents = [.custom { _ in 280 }]
+            sheet.prefersGrabberVisible = true
+        }
         presenterViewController?.present(monthYearPicker, animated: true)
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/CameraPreviewView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/CameraPreviewView.swift
@@ -15,6 +15,9 @@ protocol CameraPreviewDelegate: AnyObject {
     func cameraPreviewPermissionDenied(_ view: CameraPreviewView)
 }
 
+/// 바코드 감지 시 바운딩 박스 축소 애니메이션 완료 후 delegate에 isbn 전달
+/// (홈앱 QR 감지 애니메이션 차용)
+
 // MARK: - CameraPreviewView
 
 final class CameraPreviewView: UIView {
@@ -38,6 +41,18 @@ final class CameraPreviewView: UIView {
         view.isHidden = true
         return view
     }()
+
+    private let boundingBoxView: UIView = {
+        let view = UIView()
+        view.layer.borderColor = UIColor.systemYellow.cgColor
+        view.layer.borderWidth = 3
+        view.layer.cornerRadius = 6
+        view.backgroundColor = UIColor.systemYellow.withAlphaComponent(0.1)
+        view.isHidden = true
+        return view
+    }()
+
+    private var pendingISBN: String?
 
     // MARK: - Init
 
@@ -84,6 +99,9 @@ final class CameraPreviewView: UIView {
 
     func startScanning() {
         lastDetectedISBN = nil
+        pendingISBN = nil
+        boundingBoxView.isHidden = true
+        boundingBoxView.alpha = 0
         guard let session = captureSession, !session.isRunning else { return }
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             session.startRunning()
@@ -125,12 +143,17 @@ extension CameraPreviewView: AVCaptureMetadataOutputObjectsDelegate {
         guard let metadataObject = metadataObjects.first,
               let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject,
               let isbn = readableObject.stringValue,
-              isbn != lastDetectedISBN else { return }
+              isbn != lastDetectedISBN,
+              let previewLayer,
+              let transformedObject = previewLayer.transformedMetadataObject(for: readableObject)
+        else { return }
 
         lastDetectedISBN = isbn
+        pendingISBN = isbn
+
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.delegate?.cameraPreview(self, didDetectBarcode: isbn)
+            self.showBoundingBoxAnimation(for: transformedObject.bounds)
         }
     }
 }
@@ -144,6 +167,7 @@ private extension CameraPreviewView {
         layer.cornerRadius = 20
         clipsToBounds = true
         addSubview(focusIndicator)
+        addSubview(boundingBoxView)
     }
 
     func setupTapGesture() {
@@ -193,6 +217,49 @@ private extension CameraPreviewView {
                 }
                 device.unlockForConfiguration()
             } catch {}
+        }
+    }
+
+    func showBoundingBoxAnimation(for barcodeBounds: CGRect) {
+        // 바코드 bounds에 여유 패딩 추가
+        let padding: CGFloat = 16
+        let paddedBounds = barcodeBounds.insetBy(dx: -padding, dy: -padding)
+
+        // 초기 상태: 카메라 프리뷰 전체 크기
+        boundingBoxView.frame = bounds
+        boundingBoxView.layer.cornerRadius = 20
+        boundingBoxView.isHidden = false
+        boundingBoxView.alpha = 1
+
+        // 햅틱 피드백
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        // 바코드 크기로 축소 애니메이션 (0.6초 + 스프링)
+        UIView.animate(
+            withDuration: 0.6,
+            delay: 0,
+            usingSpringWithDamping: 0.7,
+            initialSpringVelocity: 0.3
+        ) {
+            self.boundingBoxView.frame = paddedBounds
+            self.boundingBoxView.layer.cornerRadius = 6
+        } completion: { [weak self] _ in
+            guard let self, let isbn = self.pendingISBN else { return }
+            // 바운딩 박스 잠깐 유지 후 delegate 호출
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                self.delegate?.cameraPreview(self, didDetectBarcode: isbn)
+                self.pendingISBN = nil
+            }
+        }
+    }
+
+    /// 외부에서 바운딩 박스를 숨길 때 호출
+    func hideBoundingBox() {
+        UIView.animate(withDuration: 0.2) {
+            self.boundingBoxView.alpha = 0
+        } completion: { [weak self] _ in
+            self?.boundingBoxView.isHidden = true
         }
     }
 


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #58 

## 📝 Summary
ReadingView navigationTitle 미표시, 바텀 시트 detent 깨짐, 바코드 스캔 시 바운딩 박스 애니메이션 미적용 문제를 수정했습니다.

  ## 🔨 What

  | 파일 | 변경 내용 |
  |------|----------|
  | `AppCoordinator.swift` | `showReading()`에서 `hostingVC.title` + `largeTitleDisplayMode` UIKit 레벨 설정 |
  | `ReadingLogCalendar.swift` | `monthYearTapped()`에서 present 전 sheet detent/grabber 재설정 |
  | `CameraPreviewView.swift` | `boundingBoxView` 추가 + `showBoundingBoxAnimation()` 구현 (스프링 축소 + 햅틱 + 패딩) |

  ## 🔧 Troubleshooting (트러블슈팅)

  ### 1. ReadingView navigationTitle 미표시
  - **원인**: UIHostingController를 UINavigationController에 push할 때 SwiftUI `.navigationTitle()` 모디파이어가 UIKit navigationBar와 동기화 안 됨
  - **해결**: `hostingVC.title = book.bookTitle` + `navigationItem.largeTitleDisplayMode = .never` UIKit 레벨 직접 설정

  ### 2. MonthYearPicker detent 2회차 이상 깨짐
  - **원인**: lazy var로 1회만 생성된 VC를 dismiss 후 재 present 시 `sheetPresentationController` 설정 손상
  - **해결**: `monthYearTapped()`에서 present 직전에 `sheet.detents`, `sheet.prefersGrabberVisible` 매번 재설정

  ### 3. 바코드 바운딩 박스 크기 정확도
  - **원인**: `transformedMetadataObject.bounds`가 바코드에 너무 타이트하게 맞음
  - **해결**: bounds에 16pt 패딩 추가 + 애니메이션 0.6초 스프링 + 완료 후 0.4초 대기

  ## 👀 Review Notes
  - CameraPreviewView의 바운딩 박스 애니메이션이 기존 delegate 흐름을 변경함 — 즉시 delegate 호출이 아닌 애니메이션 완료 후 호출로 변경
  - 바텀 시트 수정은 MonthYearPickerViewController 인스턴스 재사용 구조를 유지하면서 sheet만 재설정하는 방식