### PR TITLE
[Feat][#PO-74] 기본 불빛 세팅 UX 흐름에 맞게 변경

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/SceneDelegate.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/SceneDelegate.swift
@@ -26,6 +26,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
         self.window = window
+
+        // 앱 라이프사이클에 따른 조명 관리 시작 (didBecomeActive에서 디폴트 적용)
+        AppLightingService.shared.registerLifecycleObservers()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Models/LightingConfig.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Models/LightingConfig.swift
@@ -13,14 +13,17 @@ struct LightingConfig: Codable, Sendable {
     /// 밝기 (0~100)
     let brightness: Int
 
-    /// 독서 종료 시 리셋 기본값 (따뜻한 백색)
+    /// 앱 기본 조명 (따뜻한 백색) — 앱 실행/독서 종료/백그라운드 복원 공용
     static let `default` = LightingConfig(hue: 40, saturation: 20, brightness: 80)
 }
 
-/// HomeKit 조명 제어 인터페이스 (Demian 구현 예정)
+/// HomeKit 조명 제어 인터페이스
 protocol LightingControllable {
     func applyLighting(_ config: LightingConfig) async throws
     func resetLighting() async throws
+    func applyLightingWithPowerOn(_ config: LightingConfig) async throws
+    func startBrightnessPulse(base: Int, range: Int) async
+    func stopBrightnessPulse() async
 }
 
 #if DEBUG
@@ -31,6 +34,18 @@ struct MockLightingController: LightingControllable {
 
     func resetLighting() async throws {
         print("[MockLighting] 조명 리셋")
+    }
+
+    func applyLightingWithPowerOn(_ config: LightingConfig) async throws {
+        print("[MockLighting] 조명 켜기 + 적용 - H\(config.hue) S\(config.saturation) B\(config.brightness)")
+    }
+
+    func startBrightnessPulse(base: Int, range: Int) async {
+        print("[MockLighting] 밝기 펄스 시작 (base: \(base), range: \(range))")
+    }
+
+    func stopBrightnessPulse() async {
+        print("[MockLighting] 밝기 펄스 중지")
     }
 }
 #endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -58,6 +58,11 @@ final class ReadingViewModel {
         hasStarted = true
         print("[Gemini] API 요청 시작 (1회)")
 
+        // 세팅 중 밝기 펄스 시작 (UI 펄스와 동기)
+        if let controller = lightingController {
+            await controller.startBrightnessPulse(base: 80, range: 50)
+        }
+
         do {
             let environment = try await geminiService.generateReadingEnvironment(for: book)
 
@@ -69,10 +74,12 @@ final class ReadingViewModel {
             print("[Gemini] 조명: H\(environment.lighting.hue) S\(environment.lighting.saturation) B\(environment.lighting.brightness)")
             print("[Gemini] 대화 주제: \(environment.conversations.count)개")
 
-            // HomeKit 조명 설정
+            // 펄스 중지 → Gemini 색상 적용
+            AppLightingService.shared.isReadingActive = true
             if let controller = lightingController, let config = lightingConfig {
+                await controller.stopBrightnessPulse()
                 do {
-                    try await controller.applyLighting(config)
+                    try await controller.applyLightingWithPowerOn(config)
                     print("[Lighting] 조명 설정 완료")
                 } catch {
                     print("[Lighting] 조명 설정 실패: \(error.localizedDescription)")
@@ -98,6 +105,9 @@ final class ReadingViewModel {
                 startTimer()
             }
         } catch {
+            if let controller = lightingController {
+                await controller.stopBrightnessPulse()
+            }
             print("[Gemini] 오류: \(error)")
             errorMessage = "환경세팅에 오류가 발생했어요!"
             state = .error
@@ -109,9 +119,11 @@ final class ReadingViewModel {
         timerTask = nil
         audioPlayerService.stop()
         isMusicPlaying = false
+        AppLightingService.shared.isReadingActive = false
 
-        // 조명 리셋 (fire-and-forget)
+        // 펄스 중지 + 조명 리셋 (fire-and-forget)
         if let controller = lightingController {
+            Task { await controller.stopBrightnessPulse() }
             Task {
                 do {
                     try await controller.resetLighting()

--- a/LivingStory-iOS/LivingStory-iOS/Service/AppLightingService.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/AppLightingService.swift
@@ -1,0 +1,83 @@
+//
+//  AppLightingService.swift
+//  LivingStory-iOS
+//
+//  앱 라이프사이클에 따른 조명 관리
+//  - 앱 실행 시: 디폴트 색상 적용 (꺼져있으면 켜기)
+//  - 백그라운드 진입: 기본 색상(흰색)으로 복원
+//  - 포그라운드 복귀: 디폴트 색상 재적용
+//
+
+import UIKit
+
+@MainActor
+final class AppLightingService {
+
+    static let shared = AppLightingService()
+
+    /// 독서 중이면 true — 백그라운드/포그라운드 조명 변경 스킵
+    var isReadingActive = false
+
+    private let lightingController: any LightingControllable
+
+    private init() {
+        #if DEBUG
+        lightingController = MockLightingController()
+        #else
+        lightingController = HomeKitLightingController()
+        #endif
+    }
+
+    // MARK: - Lifecycle
+
+    /// 앱 시작/포그라운드 복귀 시 호출 — 디폴트 조명 적용 (꺼져있으면 켜기)
+    func applyDefaultLighting() {
+        Task {
+            do {
+                try await lightingController.applyLightingWithPowerOn(.default)
+                print("[AppLighting] 디폴트 조명 적용 완료")
+            } catch {
+                print("[AppLighting] 디폴트 조명 적용 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// 백그라운드 진입 시 호출 — 디폴트 색상으로 복원
+    func restoreDefault() {
+        Task {
+            do {
+                try await lightingController.applyLighting(.default)
+                print("[AppLighting] 디폴트 복원 완료")
+            } catch {
+                print("[AppLighting] 디폴트 복원 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Observer Setup
+
+    func registerLifecycleObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleDidBecomeActive() {
+        guard !isReadingActive else { return }
+        applyDefaultLighting()
+    }
+
+    @objc private func handleDidEnterBackground() {
+        guard !isReadingActive else { return }
+        restoreDefault()
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -36,6 +36,7 @@ final class HomeKitLightingController: NSObject, LightingControllable {
 
     private let homeManager = HMHomeManager()
     private var homesLoadedContinuation: CheckedContinuation<[HMHome], Never>?
+    private var pulseTask: Task<Void, Never>?
 
     // MARK: - Init
 
@@ -82,6 +83,90 @@ final class HomeKitLightingController: NSObject, LightingControllable {
     func resetLighting() async throws {
         try await applyLighting(.default)
         print("[HomeKit] 조명 리셋 완료 (기본값)")
+    }
+
+    /// 밝기 펄스 시작 (세팅 중 깜빡임 효과, UI 펄스와 동일한 2.5초 주기)
+    /// 단계별로 부드럽게 밝기 변경 (예: 80→65→50→65→80)
+    func startBrightnessPulse(base: Int = 80, range: Int = 50) async {
+        pulseTask?.cancel()
+        pulseTask = Task {
+            let homes = (try? await ensureHomesLoaded()) ?? []
+            let targetHome = homes.first(where: { !findLightServices(in: $0).isEmpty }) ?? homes.first
+            guard let home = targetHome else { return }
+
+            let brightChars = findLightServices(in: home).compactMap { service in
+                service.characteristics.first { $0.characteristicType == HMCharacteristicTypeBrightness }
+            }
+            guard !brightChars.isEmpty else { return }
+
+            let low = max(base - range, 10)
+            let high = min(base + range, 100)
+            let steps = 4 // 한 방향 단계 수
+            let stepDelay: Double = 0.8 / Double(steps) // 0.8초 ÷ 4 = 0.2초 간격 (한 사이클 1.6초)
+
+            while !Task.isCancelled {
+                // 밝게 → 어둡게 (단계별)
+                for i in 0...steps {
+                    guard !Task.isCancelled else { return }
+                    let brightness = high - (high - low) * i / steps
+                    for char in brightChars {
+                        try? await writeCharacteristic(char, value: brightness)
+                    }
+                    if i < steps {
+                        try? await Task.sleep(for: .seconds(stepDelay))
+                    }
+                }
+                // 어둡게 → 밝게 (단계별)
+                for i in 0...steps {
+                    guard !Task.isCancelled else { return }
+                    let brightness = low + (high - low) * i / steps
+                    for char in brightChars {
+                        try? await writeCharacteristic(char, value: brightness)
+                    }
+                    if i < steps {
+                        try? await Task.sleep(for: .seconds(stepDelay))
+                    }
+                }
+            }
+        }
+    }
+
+    /// 밝기 펄스 중지
+    func stopBrightnessPulse() async {
+        pulseTask?.cancel()
+        pulseTask = nil
+    }
+
+    /// 조명이 꺼져있어도 H/S/B를 먼저 세팅한 뒤 전원을 켜서 색상 깜빡임 방지
+    func applyLightingWithPowerOn(_ config: LightingConfig) async throws {
+        let homes = try await ensureHomesLoaded()
+        guard !homes.isEmpty else {
+            throw HomeKitLightingError.noHomesAvailable
+        }
+
+        let targetHome = homes.first(where: { !findLightServices(in: $0).isEmpty })
+            ?? homes[0]
+
+        let lightServices = findLightServices(in: targetHome)
+        guard !lightServices.isEmpty else {
+            throw HomeKitLightingError.noLightsFound
+        }
+
+        var errors: [Error] = []
+        for service in lightServices {
+            do {
+                try await writeLightingValuesThenPower(config, to: service)
+            } catch {
+                errors.append(error)
+                print("[HomeKit] 조명 적용 실패: \(error.localizedDescription)")
+            }
+        }
+
+        if errors.count == lightServices.count {
+            throw HomeKitLightingError.noLightsFound
+        }
+
+        print("[HomeKit] 조명 적용 완료 (PowerOn) - H\(config.hue) S\(config.saturation) B\(config.brightness), \(lightServices.count - errors.count)/\(lightServices.count)개 성공")
     }
 }
 
@@ -133,7 +218,7 @@ private extension HomeKitLightingController {
         }
     }
 
-    /// 조명 서비스에 HSB + 전원 값 쓰기
+    /// 조명 서비스에 전원 켜기 → HSB 값 쓰기 (기존 방식)
     func writeLightingValues(_ config: LightingConfig, to service: HMService) async throws {
         // 전원 켜기
         if let powerChar = service.characteristics.first(where: {
@@ -161,6 +246,35 @@ private extension HomeKitLightingController {
             $0.characteristicType == HMCharacteristicTypeBrightness
         }) {
             try await writeCharacteristic(brightChar, value: config.brightness)
+        }
+    }
+
+    /// HSB를 먼저 세팅한 뒤 전원을 켜서 색상 깜빡임 방지
+    func writeLightingValuesThenPower(_ config: LightingConfig, to service: HMService) async throws {
+        // 1. 색상/채도/밝기 먼저 세팅 (전원 끈 상태에서도 값은 쓸 수 있음)
+        if let hueChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeHue
+        }) {
+            try await writeCharacteristic(hueChar, value: Float(config.hue))
+        }
+
+        if let satChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeSaturation
+        }) {
+            try await writeCharacteristic(satChar, value: Float(config.saturation))
+        }
+
+        if let brightChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypeBrightness
+        }) {
+            try await writeCharacteristic(brightChar, value: config.brightness)
+        }
+
+        // 2. 마지막에 전원 켜기 → 세팅된 색상으로 바로 켜짐
+        if let powerChar = service.characteristics.first(where: {
+            $0.characteristicType == HMCharacteristicTypePowerState
+        }) {
+            try await writeCharacteristic(powerChar, value: true)
         }
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -132,7 +132,6 @@ extension HomeKitManager: HMAccessoryDelegate {
     /// 액세서리의 특성 값이 변경되면 호출 (외부 앱, 자동화, 물리 제어 등)
     func accessory(_ accessory: HMAccessory, service: HMService,
                    didUpdateValueFor characteristic: HMCharacteristic) {
-        print("[HomeKit] 특성 변경 감지: \(accessory.name) - \(characteristic.characteristicType) = \(String(describing: characteristic.value))")
         // 디바운싱: 150ms 내 연속 변경을 최종 1회로 합침 (밝기 슬라이더 등)
         pendingUpdateTask?.cancel()
         pendingUpdateTask = Task { @MainActor in


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #60 

  ## 📝 Summary
  앱 라이프사이클에 따른 조명 관리 + 독서 세팅 중 밝기 펄스 + 색상 깜빡임 방지를 구현했습니다.

  ## 🏗 Architecture Decision (설계 의사결정)

  ### 1. AppLightingService 분리
  - **문제**: 앱 시작/백그라운드/포그라운드 시 조명 관리가 필요한데, 기존 어디에도 담당 로직 없음
  - **선택**: 싱글톤 `AppLightingService`로 분리. SceneDelegate에서 옵저버만 등록하고, 라이프사이클 이벤트에 따라 자동 동작

  ### 2. H/S/B 선세팅 → 전원 켜기 순서
  - **문제**: 조명이 꺼진 상태에서 Power → H → S → B 순서로 적용하면 이전 색상이 잠깐 보임
  - **선택**: `writeLightingValuesThenPower`로 H/S/B를 먼저 쓴 뒤 마지막에 전원 켜기

  ### 3. 독서 중 조명 보호 플래그
  - **문제**: 독서 중 백그라운드 → 포그라운드 복귀 시 Gemini 색상이 디폴트로 덮어씌워짐
  - **선택**: `isReadingActive` 플래그로 독서 중이면 라이프사이클 조명 변경 스킵

  ## 🔨 What

  | 파일 | 변경 내용 |
  |------|----------|
  | `LightingConfig.swift` | `applyLightingWithPowerOn`/`startBrightnessPulse`/`stopBrightnessPulse` 프로토콜 추가 |
  | `HomeKitLightingController.swift` | H/S/B 선세팅 + 단계별 밝기 펄스 구현 (80↔30, 0.2초 간격) |
  | `AppLightingService.swift` | 앱 라이프사이클 조명 관리 (신규) |
  | `SceneDelegate.swift` | AppLightingService 옵저버 등록 |
  | `ReadingViewModel.swift` | 세팅 중 펄스 시작/중지 + isReadingActive 플래그 |
  | `HomeKitManager.swift` | 디버그 로그 제거 |

  ## 🔧 Troubleshooting (트러블슈팅)

  ### 1. 독서 중 백그라운드 복귀 시 Gemini 색상 유실
  - **원인**: AppLightingService가 포그라운드 복귀마다 디폴트 색상을 적용
  - **해결**: `isReadingActive` 플래그 — 독서 중이면 라이프사이클 조명 변경 스킵

  ### 2. 세팅 중지 시 펄스 미중지
  - **원인**: `stopReading()`에서 `stopBrightnessPulse()` 호출 누락
  - **해결**: stopReading/에러/Gemini성공 모든 경로에서 펄스 중지 보장

  ## 👀 Review Notes

  ### 정상 동작 흐름
  - 앱 실행 → 디폴트 조명(따뜻한 백색) 적용 (꺼져있으면 켜기)
  - 독서 시작 → 밝기 펄스(80↔30) → Gemini 완료 → 펄스 중지 → Gemini 색상 적용
  - 독서 중 앱 나갔다 돌아옴 → Gemini 색상 유지
  - 독서 끝 → 디폴트 복원
  - 앱 나감 → 디폴트 복원 (독서 중이면 스킵)
  - 스와이프 킬 → 다음 실행 시 자동 복원
  - Gemini/조명 실패 → 펄스 중지 + 에러 alert

  ### 허용 범위 내 제한
  - 독서 시작 시 조명이 이미 켜져있으면 H/S/B 순차 변경이 약간 보일 수 있음 ("환경 세팅중..." + 펄스 중이라 실질적 영향 적음)