### PR TITLE
[Hotfix][#PO-80] UT 전 독서 플로우 UX 라이팅 및 UI 수정

### DIFF
--- a/LivingStory-iOS/Info.plist
+++ b/LivingStory-iOS/Info.plist
@@ -49,6 +49,8 @@
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9S8SHSW95K;
+				DEVELOPMENT_TEAM = 8FKM9FB4PH;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -343,7 +343,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9S8SHSW95K;
+				DEVELOPMENT_TEAM = 8FKM9FB4PH;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -55,7 +55,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
@@ -487,7 +487,6 @@ struct ReadingLogCalendar: View {
             headerRow
                 .padding(.horizontal, 16)
             weekdayRow
-                .border(.red)
             dayGrid
                 .padding(.horizontal, 16)
         }
@@ -501,7 +500,7 @@ struct ReadingLogCalendar: View {
         HStack {
             HStack(spacing: 4) {
                 Text(monthYearString)
-                    .font(.title3Emphasized)
+                    .font(.headline)
                 Image(systemName: "chevron.right")
                     .font(.subheadline)
                     .fontWeight(.bold)

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
@@ -38,7 +38,7 @@ final class ReadingLogCalendarUIView: UIView {
     }()
 
     private let cal = Calendar.current
-    private let weekdayTitles = ["일", "월", "화", "수", "목", "금", "토"]
+    private let weekdayTitles = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
     private let weekdayColor = UIColor(red: 0.235, green: 0.235, blue: 0.263, alpha: 0.3)
 
     // MARK: - UI Components
@@ -479,15 +479,20 @@ struct ReadingLogCalendar: View {
     @State private var displayedMonth = Date()
 
     private let calendar = Calendar.current
-    private let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
+    private let weekdays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
     private let weekdayColor = Color(red: 0.235, green: 0.235, blue: 0.263).opacity(0.3)
 
     var body: some View {
-        VStack(spacing: 20) {
+        VStack(spacing: 3) {
             headerRow
+                .padding(.horizontal, 16)
             weekdayRow
+                .border(.red)
             dayGrid
+                .padding(.horizontal, 16)
         }
+        .padding(.top, 13)
+        .padding(.bottom, 17)
     }
 
     // MARK: - Subviews
@@ -498,8 +503,9 @@ struct ReadingLogCalendar: View {
                 Text(monthYearString)
                     .font(.title3Emphasized)
                 Image(systemName: "chevron.right")
-                    .font(.caption2)
-                    .fontWeight(.semibold)
+                    .font(.subheadline)
+                    .fontWeight(.bold)
+                    .foregroundStyle(.yellow0)
             }
             Spacer()
             if showNavigation {
@@ -527,6 +533,7 @@ struct ReadingLogCalendar: View {
                     .frame(maxWidth: .infinity)
             }
         }
+        .padding(.horizontal, 16)
     }
 
     private var dayGrid: some View {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -32,8 +32,8 @@ enum StringLiterals {
     enum Reading {
         static let settingTitle = "환경 세팅중..."
         static let settingSubtitle = "몇 분 소요될 수 있습니다."
-        static let settingDoneTitle = "환경이 세팅 됐어요. 이제 재밌게 읽으세요!"
-        static let settingDoneSubtitle = "책 흐름에 맞게 분위기가 변할거에요.\n재밌게 책을 읽어보세요."
+        static let settingDoneTitle = "책 분위기에 맞게 환경이 세팅 됐어요!"
+        static let settingDoneSubtitle = "이제 책을 더 재밌게 읽으세요!"
         static let stopSettingAlert = "환경 세팅을 전체 중단할까요?"
         static let stopReadingAlert = "책 읽기를 그만할까요?"
         static let close = "닫기"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -46,7 +46,7 @@ enum StringLiterals {
         static let setupButton = "책 환경 세팅하기"
         static let resultTitle = "읽은 책"
         static let homeButton = "홈으로"
-        static func todayBookCount(_ count: Int) -> String { "오늘 \(count)권의 책을 읽었어요!" }
+        static func todayBookCount(_ count: Int) -> String { "오늘 아이에게\n책을 \(count)번 읽어줬어요!" }
     }
 
     enum Book {
@@ -88,10 +88,10 @@ enum StringLiterals {
 
     enum My {
         static let title = "마이"
-        static let monthlyBookCount = "이번 달 읽은 책 수"
+        static let monthlyBookCount = "이번 달 읽어준 횟수"
         static let totalBookCount = "총 읽은 책 수"
         static let totalReadingTime = "총 읽은 시간"
-        static let bookUnit = "권"
+        static let bookUnit = "번"
         static let hourUnit = "시간"
         static let minuteUnit = "분"
         static let secondUnit = "초"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
@@ -80,6 +80,7 @@ enum SymbolLiterals: String {
 
     // MARK: - Reading
 
+    case conversation = "ellipsis.message.fill"
     case musicNoteHouse = "music.note.house.fill"
     case play = "play.fill"
     case pause = "pause.fill"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -14,13 +14,17 @@ struct ResultView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text(StringLiterals.Reading.todayBookCount((try? repository.fetchTodaySessions().count) ?? 0))
                     .font(.title2Emphasized)
-                    .padding(.top, 33)
+                    .padding(.top, 18)
+                    .padding(.horizontal, 20)
 
                 ReadingLogCalendar(readDates: (try? repository.fetchReadDates()) ?? [], showNavigation: false)
-                    .padding(.top, 33)
+                    .border(.red)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 20)
+                    
 
                 StatCard(
                     icon: SymbolLiterals.calendar.rawValue,
@@ -28,9 +32,8 @@ struct ResultView: View {
                     value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.bookUnit)",
                     isWide: true
                 )
+                .padding(.horizontal, 20)
             }
-            .padding(.horizontal, 20)
-
             Spacer()
 
             PrimaryButtonSwiftUI(title: StringLiterals.Reading.homeButton) {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -21,7 +21,6 @@ struct ResultView: View {
                     .padding(.horizontal, 20)
 
                 ReadingLogCalendar(readDates: (try? repository.fetchReadDates()) ?? [], showNavigation: false)
-                    .border(.red)
                     .padding(.horizontal, 12)
                     .padding(.top, 20)
                     

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -21,16 +21,25 @@ struct StopReadingView: View {
         .navigationTitle(bookTitle)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
     }
 
     // MARK: - Subviews
 
     private var conversationSection: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            Text(StringLiterals.Reading.conversationPrompt)
-                .font(.title2Emphasized)
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Image(.conversation)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 26)
+                Text(StringLiterals.Reading.conversationPrompt)
+                    .font(.title2Emphasized)
+            }
+            
             ScrollView {
-                VStack(spacing: 10) {
+                VStack(spacing: 16) {
                     ForEach(conversations) { item in
                         ConversationCard(
                             question: item.question,
@@ -40,8 +49,6 @@ struct StopReadingView: View {
                 }
             }
         }
-        .padding(.top, 45)
-        .padding(.horizontal, 20)
     }
 
     private var buttonSection: some View {
@@ -49,11 +56,9 @@ struct StopReadingView: View {
             PrimaryButtonSwiftUI(title: StringLiterals.Reading.restartScan, action: {
                     coordinator.restartScanner()
                 })
-                .padding(.horizontal, 20)
             WhiteButtonSwiftUI(title: StringLiterals.Reading.stopReadingButton, action: {
                     coordinator.showResult()
                 })
-                .padding(.horizontal, 20)
         }
     }
 }
@@ -65,14 +70,11 @@ private struct ConversationCard: View {
     let effect: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            CharWrappingText(
-                text: question,
-                font: .bodyEmphasized
-            )
+        VStack(alignment: .leading, spacing: 8) {
+            CharWrappingText(text: question, font: .systemFont(ofSize: 18, weight: .medium), color: .gray10)
             CharWrappingText(
                 text: effect,
-                font: .systemFont(ofSize: 15),
+                font: .systemFont(ofSize: 16, weight: .regular),
                 color: .gray40
             )
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -94,7 +94,7 @@ struct StatCard: View {
                 }
             }
         }
-        .padding(.vertical, 12)
+        .padding(.vertical, 14)
         .padding(.leading, 10)
         .padding(.trailing, 14)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
- Closes #67

## 📝 Summary
UT(유저테스트) 전 멘토 피드백 기반 핫픽스입니다. StopReadingView·ReadingView·ResultView의 UX 라이팅 수정, 캘린더 레이아웃 개선, 앱 전체 라이트모드 고정을 포함합니다.

## 🔨 What

| 파일 | 변경 내용 |
|------|----------|
| `StopReadingView.swift` | 타이틀·질문카드 텍스트 UX 라이팅 변경 |
| `ReadingView.swift` | reading 상태 동적 텍스트 변경 |
| `ResultView.swift` | 패딩·간격 조정 |
| `ReadingLogCalendar.swift` | 요일 행 equal-width 분배, 헤더 폰트 `.headline`(17pt Semibold)로 수정 |
| `StatisticsView.swift` | 프리뷰 추가 |
| `Info.plist` | `UIUserInterfaceStyle = Light` 앱 전체 라이트모드 고정 |

## 📸 Screenshots

| Before | After |
|--------|-------|
| <img width="300" src="https://github.com/user-attachments/assets/eb792857-d3b5-4711-a8b0-97ca86b6d0b2"> | <img width="300" src="https://github.com/user-attachments/assets/f919d448-d9ab-4e09-b8cf-8fedc85e67dc"> |
| <img width="300" src="https://github.com/user-attachments/assets/99a80b09-101c-4754-9e85-6ee568cdd2d0"> | <img width="300" src="https://github.com/user-attachments/assets/b5c5a183-c50a-44d4-890f-0fd43f8478b4"> |
| <img width="300" src="https://github.com/user-attachments/assets/54f7315b-daea-450c-bafa-9b3844681d6c"> | <img width="300" src="https://github.com/user-attachments/assets/37223d9c-1754-4f54-9f9f-3d9c90eb04d4"> |


## 👀 Review Notes
- ReadingView는 `.preferredColorScheme(.dark)` 유지되어 라이트모드 고정 영향 없음
- 캘린더 헤더 폰트 디자인 스펙: SF Pro 17pt Semibold → `.headline` 매칭