### PR TITLE
[Hotfix] #PO-81 String Literal Dynamic 전환 및 환경 세팅 기기 제어

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8FKM9FB4PH;
+				DEVELOPMENT_TEAM = 9S8SHSW95K;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -343,7 +343,7 @@
 				CODE_SIGN_ENTITLEMENTS = "LivingStory-iOS/LivingStory-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8FKM9FB4PH;
+				DEVELOPMENT_TEAM = 9S8SHSW95K;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/DynamicLabel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/DynamicLabel.swift
@@ -1,0 +1,23 @@
+//
+//  DynamicLabel.swift
+//  LivingStory-iOS
+//
+//  시스템 텍스트 크기 변경 시 자동으로 폰트가 스케일링되는 UILabel 서브클래스.
+//  UIKit의 UILabel은 adjustsFontForContentSizeCategory를 수동으로 켜야
+//  Dynamic Type이 런타임에 반영되므로, 이를 기본 활성화한다.
+//
+
+import UIKit
+
+class DynamicLabel: UILabel {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        adjustsFontForContentSizeCategory = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/PaddingLabel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/PaddingLabel.swift
@@ -14,6 +14,7 @@ final class PaddingLabel: UILabel {
     init(padding: UIEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)) {
         self.padding = padding
         super.init(frame: .zero)
+        adjustsFontForContentSizeCategory = true
     }
     
     @available(*, unavailable)

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/PrimaryButton.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/PrimaryButton.swift
@@ -53,6 +53,7 @@ final class PrimaryButton: UIButton {
             return outgoing
         }
         self.configuration = config
+        self.titleLabel?.adjustsFontForContentSizeCategory = true
     }
 
     @available(*, unavailable)

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/ReadingLogCalendar.swift
@@ -38,7 +38,7 @@ final class ReadingLogCalendarUIView: UIView {
     }()
 
     private let cal = Calendar.current
-    private let weekdayTitles = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+    private let weekdayTitles = StringLiterals.Calendar.weekdays
     private let weekdayColor = UIColor(red: 0.235, green: 0.235, blue: 0.263, alpha: 0.3)
 
     // MARK: - UI Components
@@ -177,9 +177,9 @@ private extension ReadingLogCalendarUIView {
 
     func setupWeekdayRow() {
         for title in weekdayTitles {
-            let label = UILabel()
+            let label = DynamicLabel()
             label.text = title
-            label.font = .systemFont(ofSize: 13, weight: .semibold)
+            label.font = .footnoteEmphasized
             label.textColor = weekdayColor
             label.textAlignment = .center
             weekdayStack.addArrangedSubview(label)
@@ -258,9 +258,9 @@ private extension ReadingLogCalendarUIView {
         }
 
         // 숫자 라벨
-        let label = UILabel()
+        let label = DynamicLabel()
         label.text = "\(day)"
-        label.font = .systemFont(ofSize: 20, weight: .regular)
+        label.font = .title3Regular
         label.textAlignment = .center
         if isToday {
             label.textColor = .white
@@ -402,7 +402,8 @@ final class MonthYearPickerViewController: UIViewController {
     private func setupUI() {
         let doneButton = UIButton(type: .system)
         doneButton.setTitle("완료", for: .normal)
-        doneButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
+        doneButton.titleLabel?.font = .headlineRegular
+        doneButton.titleLabel?.adjustsFontForContentSizeCategory = true
         doneButton.tintColor = UIColor(named: "yellow0")
         doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
 
@@ -454,9 +455,9 @@ extension MonthYearPickerViewController: UIPickerViewDataSource, UIPickerViewDel
     }
 
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        let label = (view as? UILabel) ?? UILabel()
+        let label = (view as? DynamicLabel) ?? DynamicLabel()
         label.textAlignment = .center
-        label.font = .systemFont(ofSize: 20, weight: .regular)
+        label.font = .title3Regular
         label.text = component == 0 ? yearTitles[row] : monthTitles[row]
         return label
     }
@@ -479,7 +480,7 @@ struct ReadingLogCalendar: View {
     @State private var displayedMonth = Date()
 
     private let calendar = Calendar.current
-    private let weekdays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+    private let weekdays = StringLiterals.Calendar.weekdays
     private let weekdayColor = Color(red: 0.235, green: 0.235, blue: 0.263).opacity(0.3)
 
     var body: some View {
@@ -527,7 +528,7 @@ struct ReadingLogCalendar: View {
         HStack {
             ForEach(weekdays, id: \.self) { day in
                 Text(day)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.footnoteEmphasized)
                     .foregroundStyle(weekdayColor)
                     .frame(maxWidth: .infinity)
             }
@@ -566,7 +567,7 @@ struct ReadingLogCalendar: View {
         let isRead = isReadDay(day)
 
         return Text("\(day)")
-            .font(.system(size: 20, weight: .regular))
+            .font(.title3Regular)
             .foregroundStyle(isToday ? .white : isRead ? .yellow0 : .primary)
             .frame(maxWidth: .infinity)
             .frame(height: 44)

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/StatCardView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/StatCardView.swift
@@ -33,14 +33,14 @@ final class StatCardView: UIView {
     }()
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .subheadlineRegular
         label.textColor = .label
         return label
     }()
 
     private let valueLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .subheadlineEmphasized
         label.textColor = .label
         return label

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
@@ -35,6 +35,7 @@ extension UIFont {
     // MARK: Title
     static let title1Emphasized: UIFont = scaled(.title1, size: 28, weight: .bold)
     static let title2Emphasized: UIFont = scaled(.title2, size: 22, weight: .bold)
+    static let title3Regular: UIFont = scaled(.title3, size: 20, weight: .regular)
     static let title3Emphasized: UIFont = scaled(.title3, size: 20, weight: .semibold)
 
     // MARK: Headline / Subheadline
@@ -43,11 +44,13 @@ extension UIFont {
     static let subheadlineEmphasized: UIFont = scaled(.subheadline, size: 15, weight: .semibold)
 
     // MARK: Body
+    static let bodyLargeMedium: UIFont = scaled(.body, size: 18, weight: .medium)
     static let bodyRegular: UIFont = scaled(.body, size: 17, weight: .regular)
     static let bodyMedium: UIFont = scaled(.body, size: 17, weight: .medium)
     static let bodyEmphasized: UIFont = scaled(.body, size: 17, weight: .semibold)
 
     // MARK: Callout
+    static let calloutRegular: UIFont = scaled(.callout, size: 16, weight: .regular)
     static let calloutEmphasized: UIFont = scaled(.callout, size: 16, weight: .semibold)
 
     // MARK: Footnote
@@ -78,6 +81,7 @@ extension Font {
     // MARK: Title
     static let title1Emphasized: Font = .system(.title, weight: .bold)
     static let title2Emphasized: Font = .system(.title2, weight: .bold)
+    static let title3Regular: Font = .system(.title3, weight: .regular)
     static let title3Emphasized: Font = .system(.title3, weight: .semibold)
 
     // MARK: Headline / Subheadline
@@ -86,11 +90,13 @@ extension Font {
     static let subheadlineEmphasized: Font = .system(.subheadline, weight: .semibold)
 
     // MARK: Body
+    static let bodyLargeMedium: Font = .system(size: 18, weight: .medium)
     static let bodyRegular: Font = .system(.body, weight: .regular)
     static let bodyMedium: Font = .system(.body, weight: .medium)
     static let bodyEmphasized: Font = .system(.body, weight: .semibold)
 
     // MARK: Callout
+    static let calloutRegular: Font = .system(.callout, weight: .regular)
     static let calloutEmphasized: Font = .system(.callout, weight: .semibold)
 
     // MARK: Footnote

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -91,10 +91,15 @@ enum StringLiterals {
         static let monthlyBookCount = "이번 달 읽어준 횟수"
         static let totalBookCount = "총 읽은 책 수"
         static let totalReadingTime = "총 읽은 시간"
-        static let bookUnit = "번"
+        static let bookUnit = "권"
+        static let readingUnit = "번"
         static let hourUnit = "시간"
         static let minuteUnit = "분"
         static let secondUnit = "초"
+    }
+
+    enum Calendar {
+        static let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
     }
 
     enum Onboarding {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Persistence/Repositories/ReadingSessionRepository.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Persistence/Repositories/ReadingSessionRepository.swift
@@ -93,7 +93,7 @@ final class ReadingSessionRepository: ReadingSessionRepositoryProtocol {
         )
         return try context.fetch(request).map { $0.toProfile() }
     }
-    
+
     func fetchMonthlyBookCount() throws -> Int {
         let calendar = Calendar.current
         let now = Date()
@@ -107,8 +107,10 @@ final class ReadingSessionRepository: ReadingSessionRepositoryProtocol {
             endOfMonth as NSDate
         )
         let sessions = try context.fetch(request)
-        let uniqueISBNs = Set(sessions.compactMap { $0.book?.isbn })
-        return uniqueISBNs.count
+        // TODO: 고유 책 수가 아닌 읽어준 횟수(세션 수) 기준으로 변경
+        // let uniqueISBNs = Set(sessions.compactMap { $0.book?.isbn })
+        // return uniqueISBNs.count
+        return sessions.count
     }
 
     func fetchTotalBookCount() throws -> Int {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Book/Views/CarouselCell.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Book/Views/CarouselCell.swift
@@ -31,7 +31,7 @@ final class CarouselCell: UICollectionViewCell {
     }()
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .bodyEmphasized
         label.textColor = UIColor(named: "gray10")
         label.numberOfLines = 0

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
@@ -54,6 +54,10 @@ final class HomeDataSource {
         }
     }
 
+    func device(at indexPath: IndexPath) -> DeviceModel? {
+        diffableDataSource.itemIdentifier(for: indexPath)
+    }
+
     func applySnapshot(for home: HomeModel) {
         var snapshot = NSDiffableDataSourceSnapshot<RoomModel, DeviceModel>()
         for room in home.rooms {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
@@ -50,6 +50,7 @@ final class HomeViewController: UIViewController {
         setupHierarchy()
         setupLayout()
         homeDataSource.configure(with: roomCollectionView)
+        roomCollectionView.delegate = self
         setupEmptyStateActions()
         bindHomeKit()
 
@@ -176,6 +177,37 @@ private extension HomeViewController {
             section.boundarySupplementaryItems = [header]
 
             return section
+        }
+    }
+}
+
+// MARK: - UICollectionViewDelegate (기기 탭 토글)
+
+extension HomeViewController: UICollectionViewDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let device = homeDataSource.device(at: indexPath) else { return }
+
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+
+        // 탭 애니메이션
+        if let cell = collectionView.cellForItem(at: indexPath) {
+            UIView.animate(withDuration: 0.1, animations: {
+                cell.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+            }) { _ in
+                UIView.animate(withDuration: 0.1) {
+                    cell.transform = .identity
+                }
+            }
+        }
+
+        Task {
+            do {
+                try await homeKitManager.togglePower(for: device.id)
+            } catch {
+                print("[HomeKit] 전원 토글 실패: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/DarkRoundedButton.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/DarkRoundedButton.swift
@@ -27,6 +27,7 @@ final class DarkRoundedButton: UIButton {
             return outgoing
         }
         configuration = config
+        titleLabel?.adjustsFontForContentSizeCategory = true
     }
 
     @available(*, unavailable)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeDeviceCardView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeDeviceCardView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class HomeDeviceCardView: UIView {
-    
+
     private var homeDeviceType: HomeDeviceType
     private var homeDeviceState: Bool = false
     
@@ -27,13 +27,13 @@ final class HomeDeviceCardView: UIView {
     }()
     
     private let deviceNameLabel: UILabel = {
-        let nameLabel = UILabel()
+        let nameLabel = DynamicLabel()
         nameLabel.font = .subheadlineEmphasized
         return nameLabel
     }()
     
     private let deviceStatusLabel: UILabel = {
-        let stateLabel = UILabel()
+        let stateLabel = DynamicLabel()
         stateLabel.font = .footnoteRegular
         return stateLabel
     }()
@@ -52,10 +52,11 @@ final class HomeDeviceCardView: UIView {
         self.homeDeviceType = deviceType
         
         super.init(frame: .zero)
-        
+
         setupStyle()
         setupHierarchy()
         setupLayout()
+        setupAccessibility()
         updateAppearance()
     }
     
@@ -77,6 +78,7 @@ extension HomeDeviceCardView {
         deviceNameLabel.text = device.name
         deviceStatusLabel.text = device.status
         updateAppearance()
+        updateAccessibilityLabel()
     }
 }
 
@@ -86,7 +88,19 @@ private extension HomeDeviceCardView {
         layer.cornerRadius = 20
         clipsToBounds = true
     }
-    
+
+    func setupAccessibility() {
+        isAccessibilityElement = true
+        accessibilityTraits = .button
+        accessibilityHint = "이중 탭하여 전원을 전환합니다"
+    }
+
+    func updateAccessibilityLabel() {
+        let deviceTypeName = homeDeviceType == .light ? "조명" : "스피커"
+        let stateName = homeDeviceState ? "켜짐" : "꺼짐"
+        accessibilityLabel = "\(deviceNameLabel.text ?? "") \(deviceTypeName), \(stateName)"
+    }
+
     func setupHierarchy() {
         addSubview(homeIconBackgroundView)
         homeIconBackgroundView.addSubview(homeIconDeviceImageView)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeEmptyStateView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeEmptyStateView.swift
@@ -23,7 +23,7 @@ final class HomeEmptyStateView: UIView {
     }()
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .title3Emphasized
         label.textColor = UIColor(named: "gray10")
         label.textAlignment = .center
@@ -31,7 +31,7 @@ final class HomeEmptyStateView: UIView {
     }()
 
     private let subtitleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .subheadlineRegular
         label.textColor = UIColor(named: "gray40")
         label.textAlignment = .center

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeMenuView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeMenuView.swift
@@ -103,6 +103,7 @@ private extension HomeMenuView {
         config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 30)
         
         let button = UIButton(configuration: config)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.addAction(UIAction { [weak self] _ in
             self?.selectedIndex = index
             self?.buildMenuItems()

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/RoomHeaderView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/RoomHeaderView.swift
@@ -12,7 +12,7 @@ final class RoomHeaderView: UICollectionReusableView {
     static let reuseIdentifier = "RoomHeaderView"
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .headlineRegular
         label.textColor = UIColor(named: "gray10")
         return label

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/My/MyViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/My/MyViewController.swift
@@ -137,7 +137,7 @@ private extension MyViewController {
         monthlyCard.configure(
             icon: .calendar,
             title: StringLiterals.My.monthlyBookCount,
-            value: "\(monthlyCount)\(StringLiterals.My.bookUnit)"
+            value: "\(monthlyCount)\(StringLiterals.My.readingUnit)"
         )
         totalBookCard.configure(
             icon: .books,

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Onboarding/CoachMarkOverlayView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Onboarding/CoachMarkOverlayView.swift
@@ -84,14 +84,14 @@ final class CoachMarkOverlayView: UIView {
     private let bubbleView = SpeechBubbleView()
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .subheadlineEmphasized
         label.textColor = UIColor(named: "gray100")
         return label
     }()
 
     private let messageLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .subheadlineRegular
         label.textColor = UIColor(named: "gray100")
         label.numberOfLines = 0
@@ -99,7 +99,7 @@ final class CoachMarkOverlayView: UIView {
     }()
 
     private let stepLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .footnoteRegular
         label.textColor = UIColor(named: "gray90")
         return label

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Onboarding/OnboardingViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Onboarding/OnboardingViewController.swift
@@ -34,9 +34,9 @@ final class OnboardingViewController: UIViewController {
     }()
 
     private let subtitleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.text = "나루, 이야기가 머무는 곳"
-        label.font = .systemFont(ofSize: 17, weight: .bold)
+        label.font = .bodyEmphasized
         label.textColor = .white
         label.textAlignment = .center
         return label

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -28,7 +28,7 @@ struct ResultView: View {
                 StatCard(
                     icon: SymbolLiterals.calendar.rawValue,
                     title: StringLiterals.My.monthlyBookCount,
-                    value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.bookUnit)",
+                    value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.readingUnit)",
                     isWide: true
                 )
                 .padding(.horizontal, 20)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -71,10 +71,10 @@ private struct ConversationCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            CharWrappingText(text: question, font: .systemFont(ofSize: 18, weight: .medium), color: .gray10)
+            CharWrappingText(text: question, font: .bodyLargeMedium, color: .gray10)
             CharWrappingText(
                 text: effect,
-                font: .systemFont(ofSize: 16, weight: .regular),
+                font: .calloutRegular,
                 color: .gray40
             )
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
@@ -49,7 +49,7 @@ final class ScannerViewController: UIViewController {
     // MARK: - UI Components
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.text = StringLiterals.Scanner.title
         label.font = .bodyEmphasized
         label.textColor = UIColor(named: "gray10")

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerGuideView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerGuideView.swift
@@ -20,7 +20,7 @@ final class ScannerGuideView: UIView {
     }()
 
     private let titleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.text = StringLiterals.Scanner.guideTitle
         label.font = .bodyEmphasized
         label.textColor = UIColor(named: "gray10")
@@ -28,7 +28,7 @@ final class ScannerGuideView: UIView {
     }()
 
     private let subtitleLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.text = StringLiterals.Scanner.guideSubtitle
         label.font = .subheadlineRegular
         label.textColor = UIColor(named: "gray30")

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerResultContentView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/Views/ScannerResultContentView.swift
@@ -20,7 +20,7 @@ final class ScannerResultContentView: UIView {
     }()
 
     let statusLabel: UILabel = {
-        let label = UILabel()
+        let label = DynamicLabel()
         label.font = .subheadlineRegular
         label.textColor = UIColor(named: "gray30")
         label.textAlignment = .center

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -57,7 +57,7 @@ struct StatisticsView: View {
     private var statsSection: some View {
             VStack(spacing: 12) {
                 HStack(spacing: 10) {
-                    StatCard(icon: SymbolLiterals.calendar.rawValue, title: StringLiterals.My.monthlyBookCount, value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.bookUnit)")
+                    StatCard(icon: SymbolLiterals.calendar.rawValue, title: StringLiterals.My.monthlyBookCount, value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.readingUnit)")
                     StatCard(icon: SymbolLiterals.books.rawValue, title: StringLiterals.My.totalBookCount, value: "\((try? repository.fetchTotalBookCount()) ?? 0)\(StringLiterals.My.bookUnit)")
                 }
                 StatCard(icon: SymbolLiterals.clock.rawValue, title: StringLiterals.My.totalReadingTime, value: totalTimeString, isWide: true)

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -35,6 +35,13 @@ final class HomeKitManager: NSObject {
         }
     }
 
+    /// 기기의 전원 상태를 토글 (on ↔ off)
+    func togglePower(for deviceId: UUID) async throws {
+        guard let characteristic = findPowerCharacteristic(for: deviceId) else { return }
+        let currentValue = (characteristic.value as? Bool) ?? false
+        try await characteristic.writeValue(!currentValue)
+    }
+
     /// 모든 구독 대상 특성의 최신 값을 HomeKit에서 읽어옴 (포그라운드 복귀 시 호출)
     func refreshAllCharacteristics() async {
         let subscribableTypes: Set<String> = [
@@ -178,6 +185,22 @@ private extension HomeKitManager {
                 }
             }
         }
+    }
+
+    // MARK: - Characteristic Lookup
+
+    /// deviceId에 해당하는 액세서리의 전원(PowerState) 특성을 찾아 반환
+    func findPowerCharacteristic(for deviceId: UUID) -> HMCharacteristic? {
+        for home in homeManager.homes {
+            for room in home.rooms {
+                for accessory in room.accessories where accessory.uniqueIdentifier == deviceId {
+                    return accessory.services
+                        .flatMap(\.characteristics)
+                        .first { $0.characteristicType == HMCharacteristicTypePowerState }
+                }
+            }
+        }
+        return nil
     }
 
     // MARK: - Mapping


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #69 

## 📝 Summary
하드코딩된 systemFont를 FontLiterals 기반 Dynamic Type으로 전환하고, UIKit 화면에서도 시스템 텍스트 크기 변경이 런타임에 즉시 반영되도록 DynamicLabel 서브클래스를 도입했습니다. 

환경 세팅 뷰에서 기기별 on/off 토글 기능을 추가하고, ReadingSession 기반 읽어준 횟수/책 수 단위를 분리했습니다.

### Dynamic Type 전환
  - `DynamicLabel` 서브클래스 신규 추가 (`adjustsFontForContentSizeCategory = true` 기본 설정)
  - UILabel 사용처 전체 → `DynamicLabel` 전환 (11개 파일)
  - `PaddingLabel`, UIButton(`PrimaryButton`, `DarkRoundedButton`, `HomeMenuView`, `ReadingLogCalendar`) titleLabel에도 Dynamic Type 적용
  - `FontLiterals`에 `title3Regular`, `bodyLargeMedium`, `calloutRegular` 추가
  - `OnboardingViewController`, `StopReadingView`, `ReadingLogCalendar` 하드코딩 systemFont 7곳 → FontLiterals 참조로 전환

  ### 캘린더 요일 상수 공통화
  - `ReadingLogCalendar` UIKit/SwiftUI 요일 상수 2곳 → `StringLiterals.Calendar.weekdays`로 통합

  ### 환경 세팅 뷰 기기별 on/off 토글
  - `HomeKitManager`에 `togglePower(for:)` 기기 전원 제어 메서드 추가
  - `HomeViewController`에서 `UICollectionViewDelegate.didSelectItemAt`으로 탭 토글 구현
  - 햅틱 피드백(`UIImpactFeedbackGenerator`) 및 탭 애니메이션 적용
  - `HomeDeviceCardView`에 VoiceOver 접근성(`accessibilityLabel`, `accessibilityTraits`, `accessibilityHint`) 추가

  ### ReadingSession 횟수/책 수 단위 분리
  - `fetchMonthlyBookCount` → 세션 수 기준(번)으로 변경
  - `fetchTotalBookCount` → unique ISBN 기준(권) 유지
  - `StringLiterals.My`에 `readingUnit("번")` 추가, `bookUnit`은 "권"으로 복원
  - `StatisticsView`, `MyViewController`, `ResultView`에 단위 분리 적용

  ## 🏗 Architecture Decision

  ### DynamicLabel vs open override UILabel
  - **문제**: UIKit UILabel은 시스템 텍스트 크기 변경 시 런타임 반영이 안 됨
  - **대안 1**: `UILabel.didMoveToSuperview` open override → 앱 전체 UILabel(시스템 내부 포함)에 영향, 사이드이펙트 위험
  - **선택**: `DynamicLabel` 서브클래스 → 명시적으로 사용하는 곳만 적용, 안전

  ### 기기 토글: didSelectItemAt vs 카드뷰 내 제스처
  - **문제**: 기기 카드 탭 시 on/off 토글
  - **대안 1**: `HomeDeviceCardView`에 `UITapGestureRecognizer` + `onTapped` 콜백
  - **선택**: `UICollectionViewDelegate.didSelectItemAt` → 정석 패턴, 카드뷰는 순수 표시 역할만 담당

  ## 👀 Review Notes
  - `DynamicLabel`은 UILabel과 100% 호환 (타입 업캐스팅), init에서 `adjustsFontForContentSizeCategory`만 켜줌
  - UIButton은 서브클래스가 불가하므로 `titleLabel?.adjustsFontForContentSizeCategory = true`로 직접 적용
  - 기기 토글 후 UI 갱신은 기존 `HMAccessoryDelegate.didUpdateValueFor` → `onHomesUpdated` 콜백이 자동 처리
  - 이번 달 읽어준 횟수 = 세션 수(번), 총 읽은 책 수 = unique ISBN(권)

  ## 🔮 Future Work
  - String Catalog (`.xcstrings`) 전환 검토
  - 기기 카드 롱프레스 → 밝기/볼륨 상세 제어 (Apple Home 앱 패턴)
  - 기기 토글 실패 시 토스트 에러 UI