### PR TITLE
[Hotfix][PO-82] 독서 중 백그라운드/Auto-Lock 전환 시 오디오 중단 및 복귀 처리

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -14,6 +14,7 @@ final class AppCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
 
     private var tabBarController: MainTabBarController?
+    private(set) var activeReadingViewModel: ReadingViewModel?
 
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
@@ -118,6 +119,8 @@ final class AppCoordinator: Coordinator {
             book: book,
             lightingController: lightingController
         )
+        activeReadingViewModel = viewModel
+        UIApplication.shared.isIdleTimerDisabled = true
         let view = ReadingView(coordinator: self, viewModel: viewModel)
         let hostingVC = UIHostingController(rootView: view)
         hostingVC.title = book.bookTitle
@@ -135,6 +138,8 @@ final class AppCoordinator: Coordinator {
 
     /// 독서 결과 화면 (SwiftUI)
     func showResult() {
+        activeReadingViewModel = nil
+        UIApplication.shared.isIdleTimerDisabled = false
         let view = ResultView(coordinator: self, repository: ReadingSessionRepository())
         let hostingVC = UIHostingController(rootView: view)
         (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)

--- a/LivingStory-iOS/LivingStory-iOS/Application/SceneDelegate.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/SceneDelegate.swift
@@ -36,11 +36,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-
+        appCoordinator?.activeReadingViewModel?.resume()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-
+        appCoordinator?.activeReadingViewModel?.pause()
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Services/AudioPlayerService.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Services/AudioPlayerService.swift
@@ -31,6 +31,7 @@ final class AudioPlayerService {
     }
 
     func resume() {
+        try? AVAudioSession.sharedInstance().setActive(true)
         player?.play()
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Core/Services/AudioPlayerService.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Services/AudioPlayerService.swift
@@ -26,6 +26,14 @@ final class AudioPlayerService {
         player?.play()
     }
 
+    func pause() {
+        player?.pause()
+    }
+
+    func resume() {
+        player?.play()
+    }
+
     func stop() {
         player?.stop()
         player = nil

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -48,6 +48,18 @@ final class ReadingViewModel {
         self.lightingController = lightingController
     }
 
+    // MARK: - App Lifecycle
+
+    func pause() {
+        guard state == .reading else { return }
+        audioPlayerService.pause()
+    }
+
+    func resume() {
+        guard state == .reading else { return }
+        audioPlayerService.resume()
+    }
+
     // MARK: - Public
 
     func startSetup() async {


### PR DESCRIPTION
Closes #71

## 📝 Summary
독서 중 화면 잠금(Auto-Lock), 전화 수신, 홈 이동 등 시스템 전환이 발생할 때 배경음악이 멈추고 복귀해도 다시 재생되지 않던 문제를 앱 생명주기에 맞춰 일시정지/재생되도록 처리했습니다.

추가로 독서 중에는 화면 자동 잠금(Auto-Lock)을 비활성화하고, 전화 인터럽션으로 오디오 세션이 비활성화된 경우 복귀 시 세션을 재활성화하도록 보강했습니다.

#### 앱 생명주기 기반 오디오 제어
- `AudioPlayerService`에 `pause()` / `resume()` 메서드 추가
- `ReadingViewModel`에 생명주기 진입점(`pause()` / `resume()`) 추가 — `state == .reading`일 때만 동작
- `SceneDelegate.sceneWillResignActive` → 일시정지, `sceneDidBecomeActive` → 재생 연결
- `AppCoordinator`가 활성 독서 세션(`activeReadingViewModel`)을 추적하여 전환 콜백을 전달

#### 독서 중 화면 자동 잠금 비활성화
- 독서 화면 진입 시 `UIApplication.shared.isIdleTimerDisabled = true`
- 결과 화면 이동 시 `false`로 복원

#### 전화 인터럽션 복귀 처리
- 전화 수신 시 시스템이 오디오 세션을 비활성화하므로, `resume()`에서 `AVAudioSession.setActive(true)` 후 재생하도록 보강

## 🏗 Architecture Decision
**일시정지/재생 트리거: SceneDelegate vs SwiftUI scenePhase**
- 문제: 독서 화면은 SwiftUI(`ReadingView`)지만 UIKit 코디네이터 위에 호스팅됨
- 선택: 앱 전역 전환은 `SceneDelegate`에서 받고 `AppCoordinator`가 활성 뷰모델로 위임 → 화면별 onChange 분산 없이 단일 지점에서 제어

**Auto-Lock 차단: isIdleTimerDisabled vs 백그라운드 재생 허용**
- 문제: Auto-Lock으로 화면이 꺼지면 오디오 세션이 중단됨
- 대안: `UIBackgroundModes: audio`로 잠금 후에도 계속 재생
- 선택: 취침 동화 특성상 사용자가 화면을 보며 읽는 흐름 → 독서 중 Auto-Lock 자체를 차단하고, 명시적 백그라운드(전화/홈) 전환에서만 일시정지

## 👀 Review Notes
- `pause()` / `resume()`는 `state == .reading` 가드로, 독서 외 화면에서는 동작하지 않음
- 잠금/홈 전환은 기존 `play()` 없이 `resume()`만으로 복귀됨 (세션 유지 상태)
- 전화 인터럽션은 세션이 강제 비활성화되므로 `resume()`의 `setActive(true)`로 복귀 — **시뮬레이터에서는 전화 인터럽션 재현 불가, 실기기 검증 필요**
- `isIdleTimerDisabled`는 결과 화면 진입 시 반드시 `false`로 복원되는지 확인 필요

## 🔮 Future Work
- `AVAudioSession.interruptionNotification` 직접 관찰로 `.began` / `.ended(shouldResume)` 분기 정교화
- 전화/타이머/알람 등 인터럽션 종류별 복귀 정책 세분화
- 백그라운드 재생 모드 도입 여부 재검토 (사용자 설정 옵션화)

## ✅ Test
- [x] 실기기: 독서 중 화면 잠금 → 음악 일시정지, 복귀 시 재생
- [x] 실기기: 독서 중 홈 이동 → 복귀 시 재생
- [x] 실기기: 독서 중 전화 수신 → 종료 후 복귀 시 재생
- [x] 독서 중 Auto-Lock 미발생 확인
- [x] 빌드 확인
