### PR TITLE
Closes [PO-83] 조명 미리보기 실시간 변경 작동 여부 및 속도

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Models/LightingConfig.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Models/LightingConfig.swift
@@ -17,6 +17,25 @@ struct LightingConfig: Codable, Sendable {
     static let `default` = LightingConfig(hue: 40, saturation: 20, brightness: 80)
 }
 
+/// 독서 분위기 프리셋 — 탭 한 번으로 1 write (슬라이더 대체)
+enum LightingPreset: String, CaseIterable, Sendable {
+    case focus = "집중"
+    case warm = "따뜻"
+    case relax = "휴식"
+    case emotion = "감성"
+    case cool = "차분"
+
+    var config: LightingConfig {
+        switch self {
+        case .focus:   return LightingConfig(hue: 210, saturation: 15, brightness: 100)  // 쿨 화이트
+        case .warm:    return LightingConfig(hue: 30,  saturation: 70, brightness: 85)   // 앰버
+        case .relax:   return LightingConfig(hue: 20,  saturation: 55, brightness: 65)   // 따뜻 오렌지
+        case .emotion: return LightingConfig(hue: 280, saturation: 60, brightness: 55)   // 은은한 퍼플
+        case .cool:    return LightingConfig(hue: 200, saturation: 20, brightness: 90)   // 시원한 화이트
+        }
+    }
+}
+
 /// HomeKit 조명 제어 인터페이스
 protocol LightingControllable {
     func applyLighting(_ config: LightingConfig) async throws

--- a/LivingStory-iOS/LivingStory-iOS/Core/Services/AudioPlayerService.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Services/AudioPlayerService.swift
@@ -31,6 +31,14 @@ final class AudioPlayerService {
         player = nil
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
+    
+    func setVolume(_ volume: Float) {
+        player?.volume = max(0, min(1,volume))
+    }
+    
+    var currentVolume: Float {
+        player?.volume ?? 1.0
+    }
 
     var isPlaying: Bool {
         player?.isPlaying ?? false

--- a/LivingStory-iOS/LivingStory-iOS/Core/Storage/UserData.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Storage/UserData.swift
@@ -10,4 +10,39 @@ import Foundation
 struct UserData {
     @UserDefault(key: "hasCompletedOnboarding", defaultValue: false)
     static var hasCompletedOnboarding: Bool
+
+    // 마지막으로 적용된 조명 (없으면 hue = -1)
+    @UserDefault(key: "lastLightingHue", defaultValue: -1)
+    static var lastLightingHue: Int
+
+    @UserDefault(key: "lastLightingSaturation", defaultValue: -1)
+    static var lastLightingSaturation: Int
+
+    @UserDefault(key: "lastLightingBrightness", defaultValue: -1)
+    static var lastLightingBrightness: Int
+
+    /// 마지막으로 적용된 조명 설정
+    /// - 최초 진입: `nil` 반환 → 호출자가 `.default` 로 fallback
+    /// - 이후: 사용자가 마지막으로 적용했던 값 반환
+    static var lastLightingConfig: LightingConfig? {
+        get {
+            guard lastLightingHue >= 0 else { return nil }
+            return LightingConfig(
+                hue: lastLightingHue,
+                saturation: lastLightingSaturation,
+                brightness: lastLightingBrightness
+            )
+        }
+        set {
+            if let newValue {
+                lastLightingHue = newValue.hue
+                lastLightingSaturation = newValue.saturation
+                lastLightingBrightness = newValue.brightness
+            } else {
+                lastLightingHue = -1
+                lastLightingSaturation = -1
+                lastLightingBrightness = -1
+            }
+        }
+    }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
@@ -65,9 +65,15 @@ final class HomeDataSource {
             snapshot.appendItems(room.devices, toSection: room)
         }
 
-        // 기존 아이템의 콘텐츠도 갱신 (isOn, percentage 변경 반영)
-        let existingItems = diffableDataSource.snapshot().itemIdentifiers
-        let itemsToReconfigure = snapshot.itemIdentifiers.filter { existingItems.contains($0) }
+        // 값이 실제로 바뀐 디바이스만 reconfigure (옵티미스틱 UI 자동 보호)
+        let oldItemsById = Dictionary(
+            diffableDataSource.snapshot().itemIdentifiers.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let itemsToReconfigure = snapshot.itemIdentifiers.filter { newItem in
+            guard let oldItem = oldItemsById[newItem.id] else { return false }
+            return oldItem.isOn != newItem.isOn || oldItem.percentage != newItem.percentage
+        }
         if !itemsToReconfigure.isEmpty {
             snapshot.reconfigureItems(itemsToReconfigure)
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
@@ -19,6 +19,9 @@ final class HomeViewController: UIViewController {
     private var currentHome: HomeModel?
     private var currentEmptyState: HomeState = .noDevices
 
+    /// 토글 진행 중인 디바이스 ID — 재탭 차단 (HomeKit 응답 받기 전까지)
+    private var togglingDeviceIds: Set<UUID> = []
+
     private let homeMenuButton: UIButton = {
         let button = UIButton(type: .system)
         let config = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular)
@@ -31,6 +34,7 @@ final class HomeViewController: UIViewController {
     private lazy var roomCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
         collectionView.backgroundColor = .clear
+        collectionView.delaysContentTouches = false   // 탭 즉시 인식 (시스템 ~100ms 지연 제거)
         return collectionView
     }()
 
@@ -186,27 +190,40 @@ private extension HomeViewController {
 extension HomeViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: false)
         guard let device = homeDataSource.device(at: indexPath) else { return }
 
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
+        // tapped 플래그 — 진행 중이면 재탭 무시
+        guard !togglingDeviceIds.contains(device.id) else { return }
+        togglingDeviceIds.insert(device.id)
 
-        // 탭 애니메이션
-        if let cell = collectionView.cellForItem(at: indexPath) {
-            UIView.animate(withDuration: 0.1, animations: {
-                cell.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
-            }) { _ in
-                UIView.animate(withDuration: 0.1) {
-                    cell.transform = .identity
-                }
-            }
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+
+        // 옵티미스틱 UI: 셀 즉시 토글
+        if let cell = collectionView.cellForItem(at: indexPath) as? HomeDeviceCardCell {
+            var newDevice = device
+            newDevice.isOn.toggle()
+            cell.configure(with: newDevice)
         }
 
-        Task {
+        Task { [weak self] in
+            defer {
+                Task { @MainActor in
+                    self?.togglingDeviceIds.remove(device.id)
+                }
+            }
             do {
-                try await homeKitManager.togglePower(for: device.id)
+                try await self?.homeKitManager.togglePower(for: device.id)
             } catch {
                 print("[HomeKit] 전원 토글 실패: \(error.localizedDescription)")
+                // 실패 시 cell 을 실제 상태로 즉시 복원
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          let cell = collectionView.cellForItem(at: indexPath) as? HomeDeviceCardCell,
+                          let actualDevice = self.homeDataSource.device(at: indexPath) else { return }
+                    cell.configure(with: actualDevice)
+                }
+                await self?.homeKitManager.refreshAllCharacteristics()
             }
         }
     }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -14,11 +14,17 @@ struct ReadingView: View {
 
     @State private var isPulsing = false
     @State private var showStopAlert = false
-
+    @State private var showColorWheel = false
+    
     var body: some View {
         VStack {
             Spacer()
             statusContent
+            if viewModel.state == .reading {
+                controlPanel
+                    .padding(.horizontal, 20)
+                    .padding(.top, 24)
+            }
             Spacer()
             actionButton
                 .padding(.horizontal, 20)
@@ -73,9 +79,9 @@ struct ReadingView: View {
             await viewModel.startSetup()
         }
     }
-
+    
     // MARK: - Subviews
-
+    
     private var statusContent: some View {
         VStack(spacing: 28) {
             Image(viewModel.state == .setting ? .home : .musicNoteHouse)
@@ -84,7 +90,7 @@ struct ReadingView: View {
                 .foregroundStyle(.white)
                 .frame(height: 79)
                 .id(viewModel.state)
-
+            
             VStack(spacing: 6) {
                 Text(viewModel.state == .setting ? StringLiterals.Reading.settingTitle : StringLiterals.Reading.settingDoneTitle)
                     .font(.bodyRegular)
@@ -97,7 +103,7 @@ struct ReadingView: View {
             }
         }
     }
-
+    
     private var actionButton: some View {
         PrimaryButtonSwiftUI(
             title: viewModel.state == .setting ? StringLiterals.Reading.stopSettingButton : StringLiterals.Reading.stopReadingButton
@@ -106,7 +112,7 @@ struct ReadingView: View {
         }
         .environment(\.colorScheme, .dark)
     }
-
+    
     private var lightingColor: Color {
         guard let config = viewModel.lightingConfig else {
             return .yellow0
@@ -117,6 +123,196 @@ struct ReadingView: View {
             brightness: Double(config.brightness) / 100.0
         )
     }
+    
+    // MARK: - Control Panel
+    private var controlPanel: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            // 반응 로그
+            HStack {
+                Text(viewModel.lastAction ?? "대기")
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.7))
+                Spacer()
+                if let ms = viewModel.lastLatencyMs {
+                    Text("\(ms)ms")
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.white.opacity(0.9))
+                }
+            }
+
+            // 반응시간 통계 (latencyHistory 있을 때)
+            if let avg = viewModel.avgLatencyMs,
+               let minV = viewModel.minLatencyMs,
+               let maxV = viewModel.maxLatencyMs {
+                HStack(spacing: 14) {
+                    latencyStat("평균", value: avg)
+                    latencyStat("최소", value: minV)
+                    latencyStat("최대", value: maxV)
+                    Spacer()
+                    Button {
+                        viewModel.clearLatencyHistory()
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                            .font(.caption)
+                            .foregroundStyle(.white.opacity(0.5))
+                    }
+                }
+                .font(.caption2.monospaced())
+                .foregroundStyle(.white.opacity(0.6))
+            }
+
+            // 볼륨
+            HStack(spacing: 10) {
+                Image(systemName: "speaker.wave.1.fill")
+                    .foregroundStyle(.white)
+                Slider(
+                    value: Binding(
+                        get: { viewModel.volume },
+                        set: { viewModel.setVolume($0) }
+                    ),
+                    in: 0...1
+                )
+                .tint(.white)
+                Image(systemName: "speaker.wave.3.fill")
+                    .foregroundStyle(.white)
+            }
+            
+            // 음악 카테고리 (가로 스크롤 10개 버튼)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(MusicCategory.allCases, id: \.self) { category in
+                        Button {
+                            viewModel.changeMusic(to: category)
+                        } label: {
+                            Text(category.rawValue)
+                                .font(.caption)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 7)
+                                .background(
+                                    viewModel.musicCategory == category
+                                    ? Color.white.opacity(0.35)
+                                    : Color.white.opacity(0.12)
+                                )
+                                .foregroundStyle(.white)
+                                .clipShape(Capsule())
+                        }
+                    }
+                }
+            }
+
+            // 조명 프리셋 팔레트 + 커스텀 색상환
+            HStack(spacing: 10) {
+                // Gemini 추천 버튼 (있을 때만)
+                if let geminiConfig = viewModel.geminiRecommendedLighting {
+                    Button {
+                        viewModel.applyGeminiRecommended()
+                    } label: {
+                        VStack(spacing: 4) {
+                            Circle()
+                                .fill(
+                                    Color(
+                                        hue: Double(geminiConfig.hue) / 360.0,
+                                        saturation: Double(geminiConfig.saturation) / 100.0,
+                                        brightness: Double(geminiConfig.brightness) / 100.0
+                                    )
+                                )
+                                .frame(width: 32, height: 32)
+                                .overlay(
+                                    Circle()
+                                        .stroke(.yellow, lineWidth: 2)
+                                )
+                            Text("AI")
+                                .font(.caption2)
+                                .foregroundStyle(.white)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+
+                ForEach(LightingPreset.allCases, id: \.self) { preset in
+                    Button {
+                        viewModel.applyPreset(preset)
+                    } label: {
+                        VStack(spacing: 4) {
+                            Circle()
+                                .fill(preset.previewColor)
+                                .frame(width: 32, height: 32)
+                                .overlay(
+                                    Circle()
+                                        .stroke(.white.opacity(0.4), lineWidth: 1)
+                                )
+                            Text(preset.rawValue)
+                                .font(.caption2)
+                                .foregroundStyle(.white)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+
+                // 커스텀 원형 색상환 (탭 시 sheet로 열림)
+                Button {
+                    showColorWheel = true
+                } label: {
+                    VStack(spacing: 4) {
+                        Circle()
+                            .fill(
+                                AngularGradient(
+                                    colors: [.red, .yellow, .green, .cyan, .blue, .purple, .red],
+                                    center: .center
+                                )
+                            )
+                            .frame(width: 32, height: 32)
+                            .overlay(
+                                Circle()
+                                    .stroke(.white.opacity(0.4), lineWidth: 1)
+                            )
+                        Text("커스텀")
+                            .font(.caption2)
+                            .foregroundStyle(.white)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .sheet(isPresented: $showColorWheel) {
+                ColorWheelSheet(viewModel: viewModel)
+                    .presentationDetents([.medium, .large])
+            }
+
+            // 밝기 (손 뗄 때 즉시 전송)
+            HStack(spacing: 10) {
+                Image(systemName: "sun.min.fill")
+                    .foregroundStyle(.white)
+                Slider(
+                    value: Binding(
+                        get: { Double(viewModel.lightingConfig?.brightness ?? 80) },
+                        set: { viewModel.updateLighting(brightness: Int($0)) }
+                    ),
+                    in: 10...100,
+                    onEditingChanged: { isEditing in
+                        if !isEditing {
+                            viewModel.commitLighting()  // 손 뗐을 때 즉시 전송
+                        }
+                    }
+                )
+                .tint(.white)
+                Image(systemName: "sun.max.fill")
+                    .foregroundStyle(.white)
+            }
+        }
+        .padding(16)
+        .background(.white.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func latencyStat(_ label: String, value: Int) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .foregroundStyle(.white.opacity(0.4))
+            Text("\(value)ms")
+                .foregroundStyle(.white.opacity(0.85))
+        }
+    }
+
 
     private var pulseBackground: some View {
         ZStack {
@@ -139,5 +335,133 @@ struct ReadingView: View {
                 .animation(.easeInOut(duration: 1.5), value: viewModel.state)
         }
         .ignoresSafeArea()
+    }
+}
+
+// MARK: - LightingPreset Preview Color
+
+extension LightingPreset {
+    var previewColor: Color {
+        let c = config
+        return Color(
+            hue: Double(c.hue) / 360.0,
+            saturation: Double(c.saturation) / 100.0,
+            brightness: Double(c.brightness) / 100.0
+        )
+    }
+}
+
+// MARK: - Color Wheel Sheet
+
+struct ColorWheelSheet: View {
+    let viewModel: ReadingViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // 헤더 (제목 + 적용 버튼)
+            HStack {
+                Text("색상 선택")
+                    .font(.headline)
+                Spacer()
+                Button("적용") {
+                    viewModel.commitLighting()
+                    dismiss()
+                }
+                .fontWeight(.semibold)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+
+            // 원형 색상환
+            CircularColorWheel(
+                hue: Double(viewModel.lightingConfig?.hue ?? 0),
+                saturation: Double(viewModel.lightingConfig?.saturation ?? 0),
+                onChange: { newHue, newSat in
+                    viewModel.updateLighting(hue: newHue, saturation: newSat)
+                }
+            )
+            .frame(width: 320, height: 320)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color(UIColor.systemBackground))
+    }
+}
+
+// MARK: - Circular Color Wheel
+
+struct CircularColorWheel: View {
+    let hue: Double         // 0-360
+    let saturation: Double  // 0-100
+    let onChange: (Int, Int) -> Void
+
+    var body: some View {
+        GeometryReader { geometry in
+            let size = min(geometry.size.width, geometry.size.height)
+            let radius = size / 2
+
+            ZStack {
+                // 1. 색상환 (각도별 Hue)
+                Circle()
+                    .fill(
+                        AngularGradient(
+                            gradient: Gradient(colors: [
+                                .red, .yellow, .green, .cyan, .blue, .purple, .red
+                            ]),
+                            center: .center,
+                            startAngle: .degrees(0),
+                            endAngle: .degrees(360)
+                        )
+                    )
+
+                // 2. 채도 그라디언트 (중심은 흰색)
+                Circle()
+                    .fill(
+                        RadialGradient(
+                            gradient: Gradient(colors: [.white, .white.opacity(0)]),
+                            center: .center,
+                            startRadius: 0,
+                            endRadius: radius
+                        )
+                    )
+
+                // 3. 현재 위치 표시 인디케이터
+                let angleRad = hue * .pi / 180.0
+                let distance = (saturation / 100.0) * radius
+                let indicatorX = radius + CGFloat(distance * cos(angleRad))
+                let indicatorY = radius + CGFloat(distance * sin(angleRad))
+
+                Circle()
+                    .strokeBorder(.white, lineWidth: 3)
+                    .background(Circle().fill(.clear))
+                    .frame(width: 22, height: 22)
+                    .shadow(color: .black.opacity(0.3), radius: 2)
+                    .position(x: indicatorX, y: indicatorY)
+            }
+            .frame(width: size, height: size)
+            .contentShape(Circle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let dx = value.location.x - radius
+                        let dy = value.location.y - radius
+                        let dist = sqrt(dx * dx + dy * dy)
+
+                        // 반지름 밖 터치는 원 가장자리로 클램프
+                        let clampedDist = min(dist, radius)
+
+                        // 각도 계산 (0도 = 오른쪽, 시계방향)
+                        var angle = atan2(dy, dx) * 180 / .pi
+                        if angle < 0 { angle += 360 }
+
+                        let hueDeg = Int(angle) % 360
+                        let satPercent = Int((clampedDist / radius) * 100)
+
+                        onChange(hueDeg, satPercent)
+                    }
+            )
+        }
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -20,6 +20,25 @@ final class ReadingViewModel {
     private(set) var musicCategory: MusicCategory?
     private(set) var lightingConfig: LightingConfig?
     private(set) var errorMessage: String?
+    
+    private(set) var volume: Float = 1.0
+    private(set) var lastAction: String?
+    private(set) var lastLatencyMs: Int?
+    private(set) var latencyHistory: [Int] = []
+    private(set) var geminiRecommendedLighting: LightingConfig?
+    private var pendingLightingTask: Task<Void, Never>?
+    private var pendingLightingConfig: LightingConfig?
+    private var lastSentTime: Date = .distantPast
+    private let brightnessThrottle: TimeInterval = 0.2   // 200ms (안정, 실기기 검증됨)
+    private let colorThrottle: TimeInterval = 0.25      // 250ms (H + S 2 characteristic)
+
+    // 반응시간 통계
+    var avgLatencyMs: Int? {
+        guard !latencyHistory.isEmpty else { return nil }
+        return latencyHistory.reduce(0, +) / latencyHistory.count
+    }
+    var maxLatencyMs: Int? { latencyHistory.max() }
+    var minLatencyMs: Int? { latencyHistory.min() }
 
     private(set) var readingSession: ReadingSessionProfile?
 
@@ -68,6 +87,7 @@ final class ReadingViewModel {
 
             musicCategory = environment.musicCategory
             lightingConfig = environment.lighting
+            geminiRecommendedLighting = environment.lighting
             conversations = environment.toConversationProfiles()
 
             print("[Gemini] 음악: \(environment.musicCategory.rawValue)")
@@ -80,6 +100,7 @@ final class ReadingViewModel {
                 await controller.stopBrightnessPulse()
                 do {
                     try await controller.applyLightingWithPowerOn(config)
+                    UserData.lastLightingConfig = config
                     print("[Lighting] 조명 설정 완료")
                 } catch {
                     print("[Lighting] 조명 설정 실패: \(error.localizedDescription)")
@@ -121,16 +142,9 @@ final class ReadingViewModel {
         isMusicPlaying = false
         AppLightingService.shared.isReadingActive = false
 
-        // 펄스 중지 + 조명 리셋 (fire-and-forget)
+        // 펄스 중지 (조명 리셋 안 함 — 질문 화면/다음 진입까지 마지막 조명 유지)
         if let controller = lightingController {
             Task { await controller.stopBrightnessPulse() }
-            Task {
-                do {
-                    try await controller.resetLighting()
-                } catch {
-                    print("[Lighting] 조명 리셋 실패: \(error.localizedDescription)")
-                }
-            }
         }
 
         guard let startTime else { return }
@@ -167,7 +181,133 @@ final class ReadingViewModel {
         state = .setting
         await startSetup()
     }
+    
+    func setVolume(_ value: Float) {
+        audioPlayerService.setVolume(value)
+        volume = value
+        recordAction("볼륨 \(Int(value * 100)) %", latencyMs: 0 )
+    }
+    
+    func changeMusic(to category: MusicCategory) {
+        let start = Date()
+        do {
+            try audioPlayerService.play(category: category)
+            audioPlayerService.setVolume(volume)
+            musicCategory = category
+            isMusicPlaying = true
+            let ms = Int(Date().timeIntervalSince(start)*1000)
+            recordAction("음악 -> \(category.rawValue)", latencyMs: ms)
+        } catch {
+            recordAction("음악 실패 :(error.localizedDescription)", latencyMs: nil)
+        }
+    }
+    
+    /// 드래그 중 — 쓰로틀 (밝기 100ms / 색상 250ms)
+    func updateLighting(hue: Int? = nil, saturation: Int? = nil, brightness: Int? = nil) {
+        let current = lightingConfig ?? .default
+        let newConfig = LightingConfig(
+            hue: hue ?? current.hue,
+            saturation: saturation ?? current.saturation,
+            brightness: brightness ?? current.brightness
+        )
+        lightingConfig = newConfig
+        pendingLightingConfig = newConfig
 
+        // 색상 변경이면 느린 쓰로틀, 밝기만이면 빠른 쓰로틀
+        let isColorChange = hue != nil || saturation != nil
+        let interval = isColorChange ? colorThrottle : brightnessThrottle
+
+        let elapsed = Date().timeIntervalSince(lastSentTime)
+
+        if elapsed >= interval {
+            // Leading: 바로 전송
+            lastSentTime = Date()
+            pendingLightingConfig = nil
+            pendingLightingTask?.cancel()
+            pendingLightingTask = nil
+            Task { [weak self] in
+                await self?.sendLighting(newConfig)
+            }
+        } else if pendingLightingTask == nil {
+            // Trailing: 다음 틱까지 대기 후 최신값 전송
+            let delay = interval - elapsed
+            pendingLightingTask = Task { [weak self] in
+                try? await Task.sleep(for: .milliseconds(Int(delay * 1000)))
+                guard !Task.isCancelled, let self, let config = self.pendingLightingConfig else { return }
+                self.lastSentTime = Date()
+                self.pendingLightingConfig = nil
+                self.pendingLightingTask = nil
+                await self.sendLighting(config)
+            }
+        }
+        // else: 이미 예약됨 → pendingLightingConfig만 최신값 유지
+    }
+
+    /// 손 뗐을 때 — 쓰로틀 취소 + 즉시 전송 (슬라이더 Release)
+    func commitLighting() {
+        guard let config = lightingConfig else { return }
+        pendingLightingTask?.cancel()
+        pendingLightingTask = nil
+        pendingLightingConfig = nil
+        lastSentTime = Date()
+        Task { [weak self] in
+            await self?.sendLighting(config)
+        }
+    }
+
+    /// 프리셋 탭 — 디바운스 없이 즉시 전송 (1 write)
+    func applyPreset(_ preset: LightingPreset) {
+        let newConfig = preset.config
+        lightingConfig = newConfig
+        pendingLightingTask?.cancel()
+        Task { [weak self] in
+            await self?.sendLighting(newConfig)
+        }
+    }
+
+    /// Gemini 추천 조명 재적용
+    func applyGeminiRecommended() {
+        guard let config = geminiRecommendedLighting else { return }
+        lightingConfig = config
+        pendingLightingTask?.cancel()
+        Task { [weak self] in
+            await self?.sendLighting(config)
+        }
+    }
+
+    /// 반응시간 통계 초기화
+    func clearLatencyHistory() {
+        latencyHistory.removeAll()
+    }
+
+    private func sendLighting(_ config: LightingConfig) async {
+        guard let controller = lightingController else { return }
+        let start = Date()
+        do {
+            try await controller.applyLighting(config)
+            UserData.lastLightingConfig = config
+            let ms = Int(Date().timeIntervalSince(start) * 1000)
+            recordAction(
+                "조명 H\(config.hue) S\(config.saturation) B\(config.brightness)",
+                latencyMs: ms
+            )
+        } catch {
+            recordAction("조명 실패: \(error.localizedDescription)", latencyMs: nil)
+        }
+    }
+    
+    private func recordAction(_ text: String, latencyMs: Int?) {
+        lastAction = text
+        lastLatencyMs = latencyMs
+        if let ms = latencyMs {
+            latencyHistory.append(ms)
+            // 최근 50개만 유지 (메모리 제한)
+            if latencyHistory.count > 50 {
+                latencyHistory.removeFirst(latencyHistory.count - 50)
+            }
+        }
+    }
+    
     // MARK: - Private
 
     private func startTimer() {

--- a/LivingStory-iOS/LivingStory-iOS/Service/AppLightingService.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/AppLightingService.swift
@@ -3,9 +3,8 @@
 //  LivingStory-iOS
 //
 //  앱 라이프사이클에 따른 조명 관리
-//  - 앱 실행 시: 디폴트 색상 적용 (꺼져있으면 켜기)
-//  - 백그라운드 진입: 기본 색상(흰색)으로 복원
-//  - 포그라운드 복귀: 디폴트 색상 재적용
+//  - 앱 실행/포그라운드 복귀: 마지막으로 사용된 조명 적용 (없으면 디폴트)
+//  - 백그라운드 진입: 조명 그대로 유지 (마지막 상태 보존)
 //
 
 import UIKit
@@ -30,28 +29,30 @@ final class AppLightingService {
 
     // MARK: - Lifecycle
 
-    /// 앱 시작/포그라운드 복귀 시 호출 — 디폴트 조명 적용 (꺼져있으면 켜기)
+    /// 앱 시작/포그라운드 복귀 시 호출 (꺼져있으면 켜기 포함)
+    /// - 최초 진입: `.default` 적용 (UserData 에 저장 없음)
+    /// - 이후: 마지막으로 적용된 조명 복원
     func applyDefaultLighting() {
+        let config = UserData.lastLightingConfig ?? .default
+        let isFirstLaunch = UserData.lastLightingConfig == nil
         Task {
             do {
-                try await lightingController.applyLightingWithPowerOn(.default)
-                print("[AppLighting] 디폴트 조명 적용 완료")
+                try await lightingController.applyLightingWithPowerOn(config)
+                if isFirstLaunch {
+                    print("[AppLighting] 최초 진입 — 디폴트 조명 적용")
+                } else {
+                    print("[AppLighting] 마지막 조명 복원 — H\(config.hue) S\(config.saturation) B\(config.brightness)")
+                }
             } catch {
-                print("[AppLighting] 디폴트 조명 적용 실패: \(error.localizedDescription)")
+                print("[AppLighting] 조명 적용 실패: \(error.localizedDescription)")
             }
         }
     }
 
-    /// 백그라운드 진입 시 호출 — 디폴트 색상으로 복원
+    /// 백그라운드 진입 시 호출 — 조명 그대로 유지 (no-op)
+    /// 마지막 사용자 조명을 백그라운드에서도 보존, 포그라운드 복귀 시 동일 상태 유지
     func restoreDefault() {
-        Task {
-            do {
-                try await lightingController.applyLighting(.default)
-                print("[AppLighting] 디폴트 복원 완료")
-            } catch {
-                print("[AppLighting] 디폴트 복원 실패: \(error.localizedDescription)")
-            }
-        }
+        // 의도적으로 비워둠 — 백그라운드 진입 시 조명 상태 보존
     }
 
     // MARK: - Observer Setup

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitLightingController.swift
@@ -37,6 +37,8 @@ final class HomeKitLightingController: NSObject, LightingControllable {
     private let homeManager = HMHomeManager()
     private var homesLoadedContinuation: CheckedContinuation<[HMHome], Never>?
     private var pulseTask: Task<Void, Never>?
+    private var lastAppliedConfig: LightingConfig?
+    private var lastPowerState: Bool?
 
     // MARK: - Init
 
@@ -77,10 +79,16 @@ final class HomeKitLightingController: NSObject, LightingControllable {
             throw HomeKitLightingError.noLightsFound
         }
 
+        // 모든 서비스 쓰기 끝난 뒤 상태 기록
+        lastAppliedConfig = config
+        lastPowerState = true
+
         print("[HomeKit] 조명 적용 완료 - H\(config.hue) S\(config.saturation) B\(config.brightness), \(lightServices.count - errors.count)/\(lightServices.count)개 성공")
     }
 
     func resetLighting() async throws {
+        // 상태 리셋 후 적용 → 모든 characteristic 다시 쓰기 보장
+        lastAppliedConfig = nil
         try await applyLighting(.default)
         print("[HomeKit] 조명 리셋 완료 (기본값)")
     }
@@ -166,6 +174,10 @@ final class HomeKitLightingController: NSObject, LightingControllable {
             throw HomeKitLightingError.noLightsFound
         }
 
+        // 초기 세팅 후 상태 기록
+        lastAppliedConfig = config
+        lastPowerState = true
+
         print("[HomeKit] 조명 적용 완료 (PowerOn) - H\(config.hue) S\(config.saturation) B\(config.brightness), \(lightServices.count - errors.count)/\(lightServices.count)개 성공")
     }
 }
@@ -218,34 +230,44 @@ private extension HomeKitLightingController {
         }
     }
 
-    /// 조명 서비스에 전원 켜기 → HSB 값 쓰기 (기존 방식)
+    /// 조명 서비스에 전원 켜기 → HSB 값 쓰기 (변경된 것만)
     func writeLightingValues(_ config: LightingConfig, to service: HMService) async throws {
-        // 전원 켜기
-        if let powerChar = service.characteristics.first(where: {
-            $0.characteristicType == HMCharacteristicTypePowerState
-        }) {
-            try await writeCharacteristic(powerChar, value: true)
+        let previous = lastAppliedConfig
+
+        // 전원 켜기: 아직 안 켜져 있을 때만
+        if lastPowerState != true {
+            if let powerChar = service.characteristics.first(where: {
+                $0.characteristicType == HMCharacteristicTypePowerState
+            }) {
+                try await writeCharacteristic(powerChar, value: true)
+            }
         }
 
-        // 색상 (Hue) - 지원하는 조명만
-        if let hueChar = service.characteristics.first(where: {
-            $0.characteristicType == HMCharacteristicTypeHue
-        }) {
-            try await writeCharacteristic(hueChar, value: Float(config.hue))
+        // 색상 (Hue): 이전 값과 다를 때만
+        if previous?.hue != config.hue {
+            if let hueChar = service.characteristics.first(where: {
+                $0.characteristicType == HMCharacteristicTypeHue
+            }) {
+                try await writeCharacteristic(hueChar, value: Float(config.hue))
+            }
         }
 
-        // 채도 (Saturation) - 지원하는 조명만
-        if let satChar = service.characteristics.first(where: {
-            $0.characteristicType == HMCharacteristicTypeSaturation
-        }) {
-            try await writeCharacteristic(satChar, value: Float(config.saturation))
+        // 채도 (Saturation): 이전 값과 다를 때만
+        if previous?.saturation != config.saturation {
+            if let satChar = service.characteristics.first(where: {
+                $0.characteristicType == HMCharacteristicTypeSaturation
+            }) {
+                try await writeCharacteristic(satChar, value: Float(config.saturation))
+            }
         }
 
-        // 밝기 (Brightness) - 거의 모든 조명이 지원
-        if let brightChar = service.characteristics.first(where: {
-            $0.characteristicType == HMCharacteristicTypeBrightness
-        }) {
-            try await writeCharacteristic(brightChar, value: config.brightness)
+        // 밝기 (Brightness): 이전 값과 다를 때만
+        if previous?.brightness != config.brightness {
+            if let brightChar = service.characteristics.first(where: {
+                $0.characteristicType == HMCharacteristicTypeBrightness
+            }) {
+                try await writeCharacteristic(brightChar, value: config.brightness)
+            }
         }
     }
 

--- a/LivingStory-iOS/TROUBLESHOOTING_2026-04-25.md
+++ b/LivingStory-iOS/TROUBLESHOOTING_2026-04-25.md
@@ -1,0 +1,288 @@
+# 트러블슈팅 기록 — 2026-04-25
+
+Naru 앱 (LivingStory-iOS) "독서 중 조명/음악/볼륨 실시간 제어" 기능 구현 과정의 문제 해결 기록.
+
+---
+
+## TS-01. UIKit Storyboard → Code-based 전환
+
+### Problem
+새 UIKit 프로젝트가 Storyboard 기반으로 생성되지만, 팀 컨벤션은 코드 기반 UI. Xcode 최신 버전(iOS 26) UI가 기존 튜토리얼과 달라 Main Interface 필드 위치도 바뀜.
+
+### Approach
+Storyboard 의존성을 완전히 제거하려면 4개 계층을 정리해야 함:
+1. Main.storyboard 파일 자체
+2. Info.plist의 Scene Manifest 내 `UISceneStoryboardFile`
+3. Target General의 Main Interface 필드 (Xcode 15+ 에서 제거됨)
+4. SceneDelegate의 `scene(_:willConnectTo:options:)` 내 rootViewController 수동 세팅
+
+### Action
+- Main.storyboard 파일 Project Navigator에서 Delete → Move to Trash
+- Info.plist `Application Scene Manifest → Scene Configuration → Item 0 → Storyboard Name` 항목 삭제 (2개만 남김: Configuration Name, Delegate Class Name)
+- Build Settings → `UIKit Main Storyboard File Base Name` 값 비우기 (General 탭엔 없어짐)
+- SceneDelegate 수정: `UIWindow(windowScene:)` 생성 → `window.rootViewController = ViewController()` → `self.window = window` → `window.makeKeyAndVisible()`
+
+### Result
+- 샌드박스 프로젝트(ioT-Test) 코드 기반 UIKit 전환 완료
+- 흰 배경 + 중앙 라벨 시뮬레이터 렌더 확인
+- **인사이트**: Xcode 버전에 따라 UI 경로가 바뀌므로 검색은 "Main Storyboard" 키워드로 Build Settings에서 확인하는 게 안정적
+
+---
+
+## TS-02. 프로젝트 전환: 학습용 샌드박스 → 실제 Naru 앱
+
+### Problem
+학습용 ioT-Test에 Mock UI 만들다가, 이미 `LivingStory-iOS` (Naru 앱)에 **HomeKit 권한·바코드 스캐너·Gemini API·MVVM+Coordinator·음악 파일 10개**까지 다 구현돼 있는 걸 발견. 중복 작업 위험.
+
+### Approach
+Naru 프로젝트 구조 확인 후, 이미 존재하는 `ReadingView` + `ReadingViewModel` + `HomeKitLightingController` 에 **"실시간 컨트롤 패널"** 만 추가하는 방향으로 전환.
+
+### Action
+- Naru 프로젝트 구조 스캔: Application / Core / Model / Presentation / Service 5계층 MVVM+Coordinator 확인
+- 기존 `AppLightingService` / `HomeKitLightingController` / `MusicCategory` enum / `AudioPlayerService` API 파악
+- ioT-Test는 폐기하지 않고 **학습 아카이브**로 보존
+
+### Result
+- 중복 개발 회피, 기존 아키텍처 위에 증분 기능만 추가
+- **교훈**: 프로젝트 시작 전 기존 코드베이스를 30분 탐색하는 투자가 수 시간 절약
+
+---
+
+## TS-03. Gemini API 503 "UNAVAILABLE"
+
+### Problem
+Naru 앱 실행 시 "환경세팅에 오류가 발생했어요!" 에러. Xcode 콘솔:
+```json
+{"error": {"code": 503, "status": "UNAVAILABLE",
+ "message": "This model is currently experiencing high demand..."}}
+```
+
+### Approach
+503 = 서버 과부하 = 본인 코드 문제 아님. 원인 후보:
+1. 프리뷰 모델(`gemini-3-flash-preview`)에 트래픽 몰림
+2. Google Cloud 광역 장애
+3. API 키 발급 직후 프로비저닝 지연
+
+Google AI Studio 상태 페이지에서 "Gemini API is having some issues serving recently created keys" 등 3개 공식 장애 확인.
+
+### Action
+- 안정 모델로 변경 계획: `GeminiService.swift:41` 의 URL을 `gemini-3-flash-preview` → `gemini-2.5-flash` 로 교체 권장
+- 장애 해소까지 대기
+- 재시도 로직 미구현 (과제로 남김)
+
+### Result
+- 원인 외부 요인 확인 → 디버깅 자원 낭비 안 함
+- **교훈**: 프리뷰/베타 모델은 production 금지. 에러 메시지 구조(`code`/`status`/`message`) 해석이 진단의 핵심
+
+---
+
+## TS-04. 시뮬레이터에서 HomeKit이 Mock만 쓰이는 문제
+
+### Problem
+실기기 iPhone에 빌드해도 HomeKit 연동이 안 되고 콘솔엔 `[MockLighting]` 로그만 찍힘. 실제 전구 제어 불가.
+
+### Approach
+`AppCoordinator.swift:110` 와 `AppLightingService.swift:24` 의 분기 코드 확인:
+```swift
+#if DEBUG
+lightingController = MockLightingController()
+#else
+lightingController = HomeKitLightingController()
+#endif
+```
+
+`#if DEBUG` 는 **Debug 빌드 configuration에서 항상 참**. ⌘R은 기본 Debug → **실기기에서도 Mock 사용**.
+
+### Action
+분기 조건을 **빌드 configuration 기반 → 실행 환경 기반** 으로 변경:
+```swift
+#if targetEnvironment(simulator)
+lightingController = MockLightingController()
+#else
+lightingController = HomeKitLightingController()
+#endif
+```
+
+두 파일 동일하게 수정.
+
+### Result
+- 실기기에서 Debug 빌드로 실제 HomeKit 제어 가능
+- 시뮬레이터는 여전히 Mock 유지 (HomeKit 미지원)
+- **교훈**: `#if DEBUG` 는 "개발 중이냐"지 "시뮬레이터냐"가 아님. 의도 구별 필요
+
+---
+
+## TS-05. WiZ 전구 과부하 → "조명 적용 실패" 연쇄
+
+### Problem
+슬라이더 실시간 드래그 시 수십 개 "조명 적용 실패" 로그. 30초 후 Apple Home에서 "응답없음" 표시. 1-2분 대기 후 자가복구 반복.
+
+### Approach
+시간당 write 수 분석:
+- 슬라이더 60fps × 1초 = 60 이벤트
+- 초기 디바운스 80ms × 1 apply = 초당 10 apply
+- 각 apply 내부에서 **Power + Hue + Saturation + Brightness = 4 writeValue**
+- 총 **40 writes/sec**, WiZ 안정 한계 10-20/sec의 2-4배 초과
+
+원인 3개:
+1. 슬라이더 드래그 중 continuous write
+2. 변경 없는 characteristic도 매번 write (Power=true, 불변 값들)
+3. 쓰로틀 로직이 실제로는 디바운스로 동작 (`pendingLightingTask?.cancel()`이 매 이벤트마다 실행되어 연속 드래그 시 Task가 계속 취소됨)
+
+### Action
+5단계 최적화:
+1. **디바운스 → 쓰로틀** (Leading + Trailing 구조):
+   ```swift
+   if elapsed >= throttleInterval {
+       // 즉시 전송, lastSentTime 갱신
+   } else if pendingLightingTask == nil {
+       // 예약 없을 때만 trailing 예약
+   } else {
+       // 이미 예약됨 → pendingLightingConfig만 최신값으로 업데이트
+   }
+   ```
+2. **이중 쓰로틀**: 밝기 200ms (1 characteristic) / 색상 250ms (2 characteristic) — 색상환 드래그 시 Hue+Sat 둘 다 바뀌어 write 2배라 더 긴 간격 적용
+3. **Diff write**: `HomeKitLightingController` 에 `lastAppliedConfig` / `lastPowerState` 추적 추가, 이전 값과 같으면 writeValue skip
+4. **Slider `onEditingChanged`**: 손 뗄 때 `commitLighting()` 호출 → 쓰로틀/디바운스 건너뛰고 즉시 최종값 전송 (밝기 release 시 300ms 절감)
+5. **`#if DEBUG` → `#if targetEnvironment(simulator)`**: 실기기 Debug 빌드에서도 실제 HomeKit 제어 (TS-04 연계)
+
+### Result
+| 지표 | 이전 | 이후 |
+|------|------|------|
+| 초당 writes (슬라이더 드래그) | 40+ | 5-10 |
+| 평균 응답시간 | 600-1500ms | 100-300ms |
+| "응답없음" 발생 빈도 | 30초마다 | 거의 없음 |
+| 실패 로그 비율 | 드래그 시 대부분 | 0-5% |
+
+**교훈**: 
+- 쓰로틀과 디바운스는 이름은 비슷하지만 동작이 반대 (주기적 vs 멈출 때까지)
+- IoT는 **하드웨어 한계가 SW UX를 제약**하므로, "실시간"은 항상 10Hz 이하로 타협
+- 다중 characteristic은 write 수를 **characteristic 수만큼 곱해서** 계산해야 함
+
+---
+
+## TS-06. WiZ 전구 페어링 실패 (전 사용자 인수)
+
+### Problem
+중고로 받은 WiZ 전구가 Apple Home에 페어링 안 됨. 전 사용자가 WiZ 앱에서 삭제 + Matter 세팅도 지웠다는데도 물리 리셋 5번 해도 **파란색 펄스 신호 없이 노란색만 깜빡**.
+
+### Approach
+WiZ/Matter 전구는 **3중 바인딩** 가능:
+1. WiZ 클라우드 계정
+2. Matter fabric (Apple/Google/SmartThings)
+3. 전구 내부 펌웨어 메모리
+
+"삭제 했다"고 해서 **3개가 다 지워졌다는 뜻이 아님**. 특히 본인이 과거에 페어링한 적 있으면 **본인 홈 허브(HomePod) 에도 잔재** 남아있을 가능성.
+
+### Action
+양쪽 잔재 체크리스트 실행:
+- **본인 쪽**: 홈 앱 → 홈 허브 및 브리지 → Matter 섹션 확인 → 오래된 항목 제거
+- **전 사용자 쪽**: WiZ 앱 모든 방 확인 (Offline 포함), 홈 앱의 "액세서리 제거" (방 제거 아님)
+- **물리 리셋**: 스탠드 스위치 (버튼식, 기계식) 로 정확히 5사이클, 1초 간격
+- 리셋 신호 구분:
+  - 노란색 유지 = 리셋 실패
+  - 파란색 펄스/색 순환 = 페어링 모드 진입
+
+### Result
+- 10번 이상 시도 후 파란색 펄스 확인 → Apple Home에서 페어링 시도
+- 초기 "Pairing Failed" → HomePod 재시작 + iPhone Wi-Fi 2.4GHz 확인 후 성공
+- **교훈**: IoT 중고 인수 시 "소프트 삭제" 로는 부족. **반드시 물리 리셋**. 신호 색상은 제품별로 다르니 WiZ = 파란색 펄스 기억
+
+---
+
+## TS-07. HomeKit 외부 변경이 앱 UI에 반영 안 됨
+
+### Problem
+Apple Home 앱에서 조명 토글하면 실제 전구는 빠르게 반응하지만, Naru 앱의 홈 화면 카드 UI는 상태가 갱신 안 됨.
+
+### Approach
+코드 경로 추적:
+- `HomeViewController.didSelectItemAt` → `togglePower` → `characteristic.writeValue` ✅
+- `HMAccessoryDelegate.accessory(_:service:didUpdateValueFor:)` → 이게 **외부 변경 감지 진입점**
+- `enableNotification(true)` 이 호출되려면 characteristic이 `HMCharacteristicPropertySupportsEventNotification` 속성을 노출해야 함
+
+**WiZ Matter 펌웨어가 Event Notification 속성을 inconsistent하게 제공** — 지원한다고 하고 실제로 이벤트 안 보내거나, 속성 자체를 안 노출하는 버전 있음.
+
+### Approach (대안)
+Apple Home 앱도 같은 한계를 **낙관적 UI 업데이트 + 주기적 readValue 폴링** 으로 우회.
+
+### Action
+해결책 3가지 제안:
+1. **낙관적 업데이트 (best UX)**: 탭 즉시 로컬 state 토글 → UI 갱신 → 실패 시 롤백
+2. **`readValue` 강제 호출**: `writeValue` 직후 `readValue` 를 추가로 호출 → delegate 강제 발동
+3. **하이브리드**: 1 + 2
+
+### Result
+- 근본 원인 파악 완료 (WiZ Matter 펌웨어 한계)
+- 구현은 time box 초과로 보류 — 다음 세션 과제
+- **교훈**: HomeKit "실시간 동기화"는 **벤더 펌웨어에 의존**하는 취약한 부분. 낙관적 UI가 실무 해법
+
+---
+
+## TS-08. SwiftUI ColorPicker가 사각형 — Apple Home 원형 UI 모사
+
+### Problem
+Apple Home의 색상 선택 팔레트는 **원형 (angular + radial gradient)** 인데, SwiftUI의 `ColorPicker` 는 **사각 그라디언트**. UX 일관성 부족.
+
+초기 시도: `Canvas` 에 `for x, y` 픽셀 단위 HSB 계산 → **GPU/CPU 과부하로 뷰 크래시** ("원을 그리면 터진다").
+
+### Approach
+픽셀 렌더링 포기, **벡터 그라디언트 합성**:
+- `AngularGradient` = 각도별 Hue (빨→노→초→청→파→자→빨)
+- `RadialGradient` = 중심 흰색 → 외곽 투명 (채도 표현)
+- 두 `Circle` 을 ZStack으로 겹치면 HSB 2D 평면 완성
+- `DragGesture` + `atan2` 로 터치 위치 → Hue/Saturation 역산
+
+### Action
+`CircularColorWheel` 컴포넌트 신규 작성 (약 90줄):
+```swift
+ZStack {
+    Circle().fill(AngularGradient(...))       // Hue
+    Circle().fill(RadialGradient(...))        // Saturation
+    Circle().strokeBorder(.white, lineWidth: 3)  // 인디케이터
+}
+.gesture(DragGesture(minimumDistance: 0).onChanged { value in
+    let dx = value.location.x - radius
+    let dy = value.location.y - radius
+    let dist = min(sqrt(dx*dx + dy*dy), radius)
+    var angle = atan2(dy, dx) * 180 / .pi
+    if angle < 0 { angle += 360 }
+    onChange(Int(angle) % 360, Int((dist/radius) * 100))
+})
+```
+
+팔레트 마지막 "커스텀" 버튼 탭 시 Sheet로 표시, 기존 throttle 로직(250ms 색상 쓰로틀)과 자동 연동.
+
+### Result
+- Apple Home과 거의 동일한 UX 달성 (원형, 드래그 실시간 반응)
+- **60fps 유지** (Metal GPU 가속 벡터 렌더링 덕분)
+- Canvas 픽셀 루프 대비 **성능 수십 배 개선**
+- 크래시 완전 해결
+- **교훈**: 2D 그래픽은 **픽셀 단위 계산 금지**, 벡터 shape + gradient 조합으로 대체
+
+---
+
+## 전체 요약 표
+
+| # | 문제 | 근본 원인 | 해법 | 수치 효과 |
+|---|------|---------|------|---------|
+| 01 | UIKit 코드 전환 | Storyboard 기본 템플릿 | 4계층 제거 | — |
+| 02 | 샌드박스 vs 실제 | 코드베이스 미파악 | 기존 프로젝트 탐색 | 수 시간 절약 |
+| 03 | Gemini 503 | 프리뷰 모델 과부하 | 안정 모델로 변경 | 외부 장애 회피 |
+| 04 | Mock만 쓰임 | `#if DEBUG` 오해 | `#if targetEnvironment(simulator)` | 실기기 HomeKit 활성 |
+| 05 | 조명 적용 실패 | 초당 40+ writes | 쓰로틀 + Diff write + commit | 40→8 writes/sec |
+| 06 | 페어링 실패 | 전구 내부 잔재 | 물리 리셋 5사이클 | 페어링 성공 |
+| 07 | UI 동기화 안 됨 | WiZ Matter Notification 미지원 | 낙관적 UI (보류) | 진단 완료 |
+| 08 | 색상환 크래시 | Canvas 픽셀 루프 | 벡터 그라디언트 | 60fps 달성 |
+
+---
+
+## 얻은 기술 인사이트
+
+1. **IoT = 하드웨어가 SW UX를 좌우한다** — WiZ 전구의 초당 write 한계가 슬라이더 쓰로틀 간격을 결정.
+2. **쓰로틀 ≠ 디바운스** — 연속 조작 UX 구현 시 두 개념 구별이 결정적.
+3. **Event Notification은 벤더 의존적** — 표준 준수한다고 해서 모든 기능 동작 보장 아님. 우회책 필수.
+4. **"삭제" 는 소프트웨어 삭제** — 하드웨어 바인딩은 별개, 물리 리셋 필수.
+5. **SwiftUI 그래픽은 벡터로** — 픽셀 루프는 성능 지옥, 그라디언트 합성이 해법.
+6. **빌드 configuration ≠ 실행 환경** — `#if DEBUG` 오용 주의.
+7. **UX 일관성의 숨은 비용** — "Apple 앱처럼 만들기" 는 내부 구현 추측 + 자체 구현 필요.


### PR DESCRIPTION
Closes #72

## 📝 Summary
AI가 추천한 조명을 미리보고, 슬라이더·색상환으로 **실시간 조작할 때 IoT 전구(WiZ)가 끊김 없이 따라오는지**를 검증하고 구현했습니다.

4번의 실패-개선 사이클을 거쳐 **사각 팔레트 + 디바운스(초기) → 원형 색상환 + Leading/Trailing 쓰로틀 + Diff Write(최종)** 로 수렴했고, WiZ가 견디는 초당 5–10 writes 안에서 Apple HomeApp 수준의 실시간성을 달성했습니다.

> develop에 머지된 #PO-82(오디오 생명주기)와 `AudioPlayerService`·`ReadingViewModel`이 겹쳐, develop을 머지하여 양쪽 변경(82 pause/resume/setActive + 83 volume/throttle)을 통합했습니다.

## 🔁 4단계 실패-개선 사이클 (PAAR)
| 시도 | 입력 UI | 시간 필터 | Write 효율 | 초당 writes | 평균 응답 | 결과 |
| --- | --- | --- | --- | --- | --- | --- |
| ① | 사각 팔레트 | 디바운스 80ms | 무차별 | 0–4 (멈출 때만) | 800ms+ | 드래그 중 무반응 (실시간성 0) |
| ② | 사각 팔레트 | 쓰로틀 80ms (버그=디바운스화) | 무차별 (4 char × n) | **40+** | 600–1500ms | write 폭주 → "응답없음" |
| ③ | 사각 팔레트 | 디바운스 회귀 | 무차별 | 변동 큼 | 변동 큼 | 색경계 부하 + Canvas 크래시 |
| ④ | **원형 색상환** | **Leading+Trailing (밝기 200/색상 250ms)** | **Diff Write** | **5–10** | **100–300ms** | **HomeApp 수준 ✅** |

- ②의 학습: "이름이 쓰로틀이면 동작도 쓰로틀"이 아님 — 다중 characteristic은 write 수를 N배로 곱해 계측해야 함
- ③의 학습: 알고리즘 튜닝(쓰로틀↔디바운스)으로는 한계 — **입력 공간(사각 HSB)의 공간 매핑 자체가 문제**면 시간 필터로 못 고침

## 🏗 Architecture Decision (3축 동시 개선)
**A. 입력 공간 — 사각 HSB → 원형 색상환**
- 사각: 0°↔360° 색경계가 화면 경계와 일치 → 1px 드래그에 H/S/B 동시 급변 → 부하 폭증
- 원형: 각도=Hue / 반경=Saturation 이 직교, 0°·360°가 한 점에서 만나 색경계 소멸 → 값이 점진 변화
- `CircularColorWheel`: `AngularGradient`(Hue) + `RadialGradient`(Saturation) + `atan2` 역산 — **벡터 그라디언트 합성으로 픽셀 루프(Canvas 크래시) 회피**

**B. 시간 필터 — Leading + Trailing 쓰로틀**
- 드래그 시작 즉시 1회(Leading) + 간격마다 + 손 뗄 때 마지막 값 commit(Trailing) → 실시간성 + 마지막 값 정확도 동시 확보
- 이중 임계값: 밝기 200ms(1 char) / 색상 250ms(Hue+Sat 2 char)

**C. 데이터 효율 — Diff Write**
- `lastAppliedConfig` / `lastPowerState` 추적 → 변경된 characteristic만 write, 불변값(Power=true 등) skip

## 📊 측정 결과
| 지표 | 시도 ②(악화) | 시도 ④(최종) | 개선폭 |
| --- | --- | --- | --- |
| 슬라이더 드래그 시 초당 writes | 40+ | **5–10** | **−75~80%** |
| 평균 응답시간 | 600–1500ms | **100–300ms** | **−80%** |
| "응답없음" 발생 | 30초마다 | **거의 없음** | — |
| 실패 로그 비율 | 드래그 시 대부분 | **0–5%** | best-effort 흡수 |
| 색상환 드래그 fps | 크래시 | **60fps** | 벡터 그라디언트 |

- 음악 변경 `changeMusic` 50–150ms(AVFoundation 로딩 포함), 볼륨 `setVolume` 즉시(~0ms)

## 👀 Review Notes
- develop(82) 머지로 `AudioPlayerService`에 82(pause/resume/setActive)와 83(setVolume/currentVolume), `ReadingViewModel`에 82(생명주기 pause/resume)와 83(volume/throttle/통계)가 공존 — 충돌은 서로 다른 메서드라 양쪽 보존으로 해결
- 본 PR엔 조명 외 **볼륨/음악 컨트롤(독서 미리보기 화면 구성 요소)** 이 함께 포함됨
- 이중 쓰로틀 임계값(200/250ms)은 **WiZ 기준 튜닝값** — 타 벤더(LIFX/Hue) 재측정 필요
- ⚠️ **피드백 반영 필요**: 밝기를 매우 빠르게 왕복하거나 색상 입력 한계치를 넘기면, 쓰로틀 비율을 높였을 때와 동일한 write 폭주 오류 재현 → 입력값 상한/연타 가드 추가 검토

## ⚠️ 잔존 한계
1. WiZ Matter Event Notification 미지원 — Apple Home 외부 토글 시 Naru UI 즉시 갱신 안 됨
2. 이중 쓰로틀 임계값은 WiZ 전용 튜닝값
3. Gemini API 503 시 기본값 진행하나 사용자 인지에 위화감
4. HomeKit 권한 거부 시 fallback UX 빈약

## 🔮 Future Work
- **낙관적 UI** — 탭 즉시 로컬 state 토글 → 실패 시 롤백
- **연타/한계치 가드** — 밝기 급변·색상 입력 상한 처리 (피드백)
- **벤더별 쓰로틀 프로필** — `.wiz`/`.lifx`/`.hue`
- **commitLighting 단위 테스트** — leading/trailing/commit 3 path 검증 (②의 "쓰로틀 디바운스화" 회귀 방지)
- Gemini 503 / HomeKit 권한 거부 fallback 안내 UI

## ✅ Test
- [x] 슬라이더 드래그 중 전구 추종 (밝기 200ms)
- [x] 원형 색상환 드래그 중 전구 추종 (색상 250ms), 60fps 유지, 크래시 0
- [x] 손 뗄 때 `commitLighting` 마지막 값 즉시 1회 보정
- [x] 5종 프리셋(집중/따뜻/휴식/감성/차분) 1 write 전환
- [x] 볼륨/음악 변경 즉시 반영
- [x] **밝기 초고속 왕복 / 색상 입력 한계치에서 write 폭주 재현 여부 측정** (피드백)

## 📑 코드 인덱스
| 영역 | 위치 |
| --- | --- |
| Leading/Trailing 쓰로틀 | `ReadingViewModel.swift` `updateLighting` |
| Slider release 즉시 전송 | `ReadingViewModel.swift` `commitLighting`, `ReadingView.swift` |
| 프리셋 1 write | `ReadingViewModel.swift` `applyPreset`, `LightingConfig.swift` |
| Diff write | `HomeKitLightingController.swift` |
| 원형 색상환 | `ReadingView.swift` `CircularColorWheel` / `ColorWheelSheet` |
| 반응시간 통계 | `ReadingViewModel.swift` `avgLatencyMs` 외, 최근 50 샘플 |
