### PR TITLE
[Fix][PO-87] Atomic 컬러셋 값 Figma 동기화 (yellow20/40)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Resources/Assets/Colors.xcassets/yellow20.colorset/Contents.json
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Resources/Assets/Colors.xcassets/yellow20.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x28",
-          "green" : "0xC9",
-          "red" : "0xFB"
+          "blue" : "0x24",
+          "green" : "0xCB",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Resources/Assets/Colors.xcassets/yellow40.colorset/Contents.json
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Resources/Assets/Colors.xcassets/yellow40.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x50",
-          "green" : "0xD6",
-          "red" : "0xFC"
+          "blue" : "0x4D",
+          "green" : "0xD5",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Closes #79

## 변경
| colorset | 이전 | 이후 | Figma 기준 |
|---|---|---|---|
| yellow20 | #FBC928 | #FFCB24 | Atomic/Yellow/20 |
| yellow40 | #FCD650 | #FFD54D | Atomic/Yellow/40 |

PO-84 Atomic 컬러셋 중 위 2개 값이 Figma 변수 테이블과 어긋나 있어 교정. 나머지(yellow0/60/80/900·green0·blue0·blue800)는 이미 일치하여 미수정.

## 검증
- colorset 값 변경(순수 에셋) → 컴파일 영향 없음
- 수정 후 값 = Figma 기준 일치 확인