### PR TITLE
[Refactor] [PO-86] 디자인 개편 반영 (화면 리디자인 + 네비게이션 구조 + 토큰화)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -194,6 +194,36 @@ final class AppCoordinator: Coordinator {
         activeNavigationController?.pushViewController(hostingVC, animated: true)
     }
 
+    // MARK: - 설정
+
+    /// 설정 화면 (SwiftUI)
+    func showSettings() {
+        let view = SettingsView(coordinator: self)
+        let hostingVC = UIHostingController(rootView: view)
+        activeNavigationController?.pushViewController(hostingVC, animated: true)
+    }
+
+    /// 아이 나이 설정 (SwiftUI)
+    func showChildAgeSetting() {
+        let view = ChildAgeSettingView(coordinator: self)
+        let hostingVC = UIHostingController(rootView: view)
+        activeNavigationController?.pushViewController(hostingVC, animated: true)
+    }
+
+    /// 알림 시간 설정 (SwiftUI)
+    func showNotificationTimeSetting() {
+        let view = NotificationTimeSettingView(coordinator: self)
+        let hostingVC = UIHostingController(rootView: view)
+        activeNavigationController?.pushViewController(hostingVC, animated: true)
+    }
+
+    /// 집 선택 (SwiftUI)
+    func showHomeSelection() {
+        let view = HomeSelectionView(coordinator: self)
+        let hostingVC = UIHostingController(rootView: view)
+        activeNavigationController?.pushViewController(hostingVC, animated: true)
+    }
+
     // MARK: - 공통
 
     /// 뒤로 가기

--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -55,10 +55,11 @@ final class AppCoordinator: Coordinator {
             tag: 1
         )
 
-        // Tab 3: 마이
+        // Tab 3: 마이 (MyViewController → StatisticsView 교체)
         let myNav = UINavigationController()
-        let myVC = MyViewController()
-        myVC.coordinator = self
+        let myVC = UIHostingController(
+            rootView: StatisticsView(coordinator: self, repository: ReadingSessionRepository())
+        )
         myNav.setViewControllers([myVC], animated: false)
         myNav.tabBarItem = UITabBarItem(
             title: StringLiterals.TabBar.my,
@@ -196,31 +197,15 @@ final class AppCoordinator: Coordinator {
 
     // MARK: - 설정
 
-    /// 설정 화면 (SwiftUI)
+    /// 설정 플로우 (SwiftUI) — 이 플로우만 SwiftUI NavigationStack(SettingsFlowView)이 네비바를 소유.
+    /// UIKit 호스팅의 native large 타이틀 글리치 회피. 자식(나이·알림·집)은 SwiftUI 스택 내부에서 이동.
     func showSettings() {
-        let view = SettingsView(coordinator: self)
-        let hostingVC = UIHostingController(rootView: view)
-        activeNavigationController?.pushViewController(hostingVC, animated: true)
-    }
-
-    /// 아이 나이 설정 (SwiftUI)
-    func showChildAgeSetting() {
-        let view = ChildAgeSettingView(coordinator: self)
-        let hostingVC = UIHostingController(rootView: view)
-        activeNavigationController?.pushViewController(hostingVC, animated: true)
-    }
-
-    /// 알림 시간 설정 (SwiftUI)
-    func showNotificationTimeSetting() {
-        let view = NotificationTimeSettingView(coordinator: self)
-        let hostingVC = UIHostingController(rootView: view)
-        activeNavigationController?.pushViewController(hostingVC, animated: true)
-    }
-
-    /// 집 선택 (SwiftUI)
-    func showHomeSelection() {
-        let view = HomeSelectionView(coordinator: self)
-        let hostingVC = UIHostingController(rootView: view)
+        let hostingVC = NavBarHiddenHostingController(
+            rootView: SettingsFlowView(coordinator: self)
+        )
+        // SwiftUI가 그리는 바 + UIDatePicker 등 UIKit 크롬을 다크로 (윈도우 Light 고정 무시). 탭바 숨김.
+        hostingVC.overrideUserInterfaceStyle = .dark
+        hostingVC.hidesBottomBarWhenPushed = true
         activeNavigationController?.pushViewController(hostingVC, animated: true)
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -137,8 +137,8 @@ final class AppCoordinator: Coordinator {
     }
 
     /// 아이와 대화 나누기 화면 (SwiftUI)
-    func showConversation(bookTitle: String, conversations: [ConversationProfile]) {
-        let view = ConversationView(coordinator: self, bookTitle: bookTitle, conversations: conversations)
+    func showConversation(conversations: [ConversationProfile]) {
+        let view = ConversationView(coordinator: self, conversations: conversations)
         let hostingVC = UIHostingController(rootView: view)
         (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)
     }

--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -129,9 +129,16 @@ final class AppCoordinator: Coordinator {
     }
 
     // MARK: - 마이 탭 네비게이션
-    /// 독서 중단 화면 (SwiftUI)
-    func showStopReading(bookTitle: String, conversations: [ConversationProfile]) {
-        let view = StopReadingView(coordinator: self, bookTitle: bookTitle, conversations: conversations)
+    /// 책 읽기 완료 화면 (SwiftUI)
+    func showStopReading(book: BookProfileModel, conversations: [ConversationProfile]) {
+        let view = StopReadingView(coordinator: self, book: book, conversations: conversations)
+        let hostingVC = UIHostingController(rootView: view)
+        (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)
+    }
+
+    /// 아이와 대화 나누기 화면 (SwiftUI)
+    func showConversation(bookTitle: String, conversations: [ConversationProfile]) {
+        let view = ConversationView(coordinator: self, bookTitle: bookTitle, conversations: conversations)
         let hostingVC = UIHostingController(rootView: view)
         (activeNavigationController ?? navigationController).pushViewController(hostingVC, animated: true)
     }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/BookCoverThumbnail.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/BookCoverThumbnail.swift
@@ -1,0 +1,91 @@
+//
+//  BookCoverThumbnail.swift
+//  LivingStory-iOS
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//  📕 책 표지 썸네일 (150×200) + 읽은 횟수 배지
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  BookProfileView(환경 미리보기) · StopReadingView(책 읽기 완료) 공용.
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import SwiftUI
+
+struct BookCoverThumbnail: View {
+    let coverURL: URL?
+    /// 해당 책을 몇 번째 읽었는지 (현재 더미)
+    let readCount: Int
+
+    var body: some View {
+        cover
+            .frame(width: 150, height: 200)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color(white: 0.92).opacity(0.16), lineWidth: 1)
+            }
+            // 배지를 클립된 표지 바운즈(150×200) 기준으로 고정 — 이미지 유무와 무관하게 동일 위치
+            .overlay(alignment: .bottomTrailing) {
+                ReadCountBadge(count: readCount)
+                    .offset(x: 28, y: -8)
+            }
+    }
+
+    @ViewBuilder
+    private var cover: some View {
+        if let coverURL {
+            AsyncImage(url: coverURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    Color(thumbHex: 0x2C2C2E)
+                }
+            }
+        } else {
+            Color(thumbHex: 0x2C2C2E)
+        }
+    }
+}
+
+private struct ReadCountBadge: View {
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Image(systemName: "book.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Color(thumbHex: 0xFFCB24))
+            Text("\(count)")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [Color(thumbHex: 0xFFCB24), Color(thumbHex: 0xBFEE68)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Color.black, in: Capsule())
+    }
+}
+
+private extension Color {
+    init(thumbHex hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#Preview {
+    ZStack {
+        Color(red: 0.11, green: 0.11, blue: 0.12).ignoresSafeArea()
+        BookCoverThumbnail(coverURL: nil, readCount: 4)
+    }
+    .preferredColorScheme(.dark)
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/BookStackAnimationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/BookStackAnimationView.swift
@@ -1,0 +1,87 @@
+//
+//  BookStackAnimationView.swift
+//  LivingStory-iOS
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//  📚 책 3권이 위에서 후두둑 떨어져 쌓이는 애니메이션
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  읽은 권수와 무관하게 항상 3권. 결과창(ResultView) 중앙 그래픽.
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import SwiftUI
+
+struct BookStackAnimationView: View {
+
+    private let count = 3
+    private let barWidth: CGFloat = 110
+    private let barHeight: CGFloat = 18
+    private let verticalGap: CGFloat = 12
+
+    /// 책/스트릭 공용 그라데이션 색 (노랑 → 연두 → 파랑)
+    static let gradientColors: [Color] = [
+        Color(hex: 0xF2D74E),
+        Color(hex: 0x7BDB8A),
+        Color(hex: 0x5AC8E8)
+    ]
+
+    static var barGradient: LinearGradient {
+        LinearGradient(colors: gradientColors, startPoint: .leading, endPoint: .trailing)
+    }
+
+    @State private var landed = false
+
+    var body: some View {
+        ZStack {
+            ForEach(0..<count, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Self.barGradient)
+                    .frame(width: barWidth, height: barHeight)
+                    .rotationEffect(.degrees(angle(index)))
+                    .offset(y: landed ? finalY(index) : finalY(index) - 320)
+                    .opacity(landed ? 1 : 0)
+                    .animation(
+                        .spring(response: 0.5, dampingFraction: 1)
+                        .delay(Double(index) * 0.15),
+                        value: landed
+                    )
+            }
+        }
+        .frame(height: (barHeight + verticalGap) * CGFloat(count) + 8)
+        .onAppear { landed = true }
+    }
+
+    // 아래(index 0) → 위(index 2)로 쌓임
+    private func finalY(_ index: Int) -> CGFloat {
+        let step = barHeight + verticalGap
+        return CGFloat(count - 1 - index) * step - CGFloat(count - 1) * step / 2
+    }
+
+    // 책처럼 살짝 비스듬히 던져진 각도
+    private func angle(_ index: Int) -> Double {
+        switch index {
+        case 0: return 0   // 아래
+        case 1: return -5    // 중간
+        default: return 7  // 위
+        }
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        BookStackAnimationView()
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/CheckmarkTransitionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/CheckmarkTransitionView.swift
@@ -1,0 +1,90 @@
+//
+//  CheckmarkTransitionView.swift
+//  LivingStory-iOS
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//  ✅ 체크마크 그리기 전환 인터랙션
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  검은 전체화면에 그라데이션 체크가 펜으로 그려지듯 나타났다가, onFinished 호출.
+//  독서 종료 등 "완료" 전환 연출에 재사용 가능.
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import SwiftUI
+
+struct CheckmarkTransitionView: View {
+
+    /// 체크 그리기 + 정지 후 호출 (다음 화면 전환 트리거)
+    let onFinished: () -> Void
+
+    /// 그리기 시간
+    private let drawDuration: Double = 0.7
+    /// 그리기 완료 후 정지(다음 화면 넘어가기 전)
+    private let holdDuration: Double = 0.7
+
+    @State private var progress: CGFloat = 0
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .ignoresSafeArea()
+
+            CheckShape()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    LinearGradient(
+                        colors: [
+                            Color(checkHex: 0xFFCB24), // 노랑 (좌하단)
+                            Color(checkHex: 0xBFEE68), // 연두 (중앙)
+                            Color(checkHex: 0x4AC3E8)  // 청록 (우상단 끝)
+                        ],
+                        startPoint: .bottomLeading,
+                        endPoint: .topTrailing
+                    ),
+                    style: StrokeStyle(lineWidth: 16, lineCap: .round, lineJoin: .round)
+                )
+                .frame(width: 120, height: 120)
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: drawDuration)) {
+                progress = 1
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + drawDuration + holdDuration) {
+                onFinished()
+            }
+        }
+    }
+}
+
+// MARK: - Check Shape
+
+/// 체크마크 path (좌측 → 하단 꼭짓점 → 우상단)
+private struct CheckShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+        var path = Path()
+        path.move(to: CGPoint(x: w * 0.20, y: h * 0.52))
+        path.addLine(to: CGPoint(x: w * 0.42, y: h * 0.72))
+        path.addLine(to: CGPoint(x: w * 0.80, y: h * 0.30))
+        return path
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(checkHex hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    CheckmarkTransitionView(onFinished: {})
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/CheckmarkTransitionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/CheckmarkTransitionView.swift
@@ -8,6 +8,11 @@
 //
 //  검은 전체화면에 그라데이션 체크가 펜으로 그려지듯 나타났다가, onFinished 호출.
 //  독서 종료 등 "완료" 전환 연출에 재사용 가능.
+//
+//  ▸ 모양: Figma 내보낸 SVG(viewBox 96×77)의 fill path를 좌표 그대로 옮긴 닫힌 도형.
+//  ▸ 연출: 정확한 도형을 그라데이션으로 채워두고, 중심선(spine)을 따라가는 굵은
+//          stroke를 .trim 으로 키워 mask 로 덮음 → 왼팔→꼭짓점→우상단 끝 순서로
+//          "펜으로 그려지듯" 정확한 픽셀이 드러난다.
 //  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 import SwiftUI
@@ -22,6 +27,11 @@ struct CheckmarkTransitionView: View {
     /// 그리기 완료 후 정지(다음 화면 넘어가기 전)
     private let holdDuration: Double = 0.7
 
+    /// 렌더 크기 — Figma SVG 원본 크기(96×77 = 체크 글리프의 실제 크기) 그대로.
+    /// SVG width/height는 '체크 바운딩 박스'이지 Figma의 120×120 프레임이 아니다.
+    /// (풀스크린 검정 배경이라 프레임 여백은 보이지 않고, 체크 절대 크기만 의미 있음.)
+    private let renderSize = CGSize(width: 96, height: 77)
+
     @State private var progress: CGFloat = 0
 
     var body: some View {
@@ -29,21 +39,18 @@ struct CheckmarkTransitionView: View {
             Color.black
                 .ignoresSafeArea()
 
-            CheckShape()
-                .trim(from: 0, to: progress)
-                .stroke(
-                    LinearGradient(
-                        colors: [
-                            Color(checkHex: 0xFFCB24), // 노랑 (좌하단)
-                            Color(checkHex: 0xBFEE68), // 연두 (중앙)
-                            Color(checkHex: 0x4AC3E8)  // 청록 (우상단 끝)
-                        ],
-                        startPoint: .bottomLeading,
-                        endPoint: .topTrailing
-                    ),
-                    style: StrokeStyle(lineWidth: 16, lineCap: .round, lineJoin: .round)
+            FigmaCheckShape()
+                .fill(checkGradient)
+                .frame(width: renderSize.width, height: renderSize.height)
+                // 중심선 따라가는 굵은 stroke를 trim으로 키워 도형을 점진적으로 드러냄(펜-드로잉)
+                .mask(
+                    CheckSpine()
+                        .trim(from: 0, to: progress)
+                        .stroke(
+                            style: StrokeStyle(lineWidth: 28, lineCap: .round, lineJoin: .round)
+                        )
+                        .frame(width: renderSize.width, height: renderSize.height)
                 )
-                .frame(width: 120, height: 120)
         }
         .onAppear {
             withAnimation(.easeInOut(duration: drawDuration)) {
@@ -54,20 +61,88 @@ struct CheckmarkTransitionView: View {
             }
         }
     }
+
+    /// Figma 그라데이션(userSpaceOnUse) 복제: 우상단 파랑 → 중앙 연두 → 좌하단 노랑.
+    /// 시작/끝 점은 Figma 벡터 좌표를 viewBox(96×77)로 정규화한 값(범위 밖 좌표 허용).
+    private var checkGradient: LinearGradient {
+        LinearGradient(
+            stops: [
+                .init(color: Color(checkHex: 0x63B0FF), location: 0.159), // 파랑
+                .init(color: Color(checkHex: 0xBFEE68), location: 0.421), // 연두
+                .init(color: Color(checkHex: 0xFFCB24), location: 0.788)  // 노랑
+            ],
+            startPoint: UnitPoint(x: 95.0329 / 96, y: 65.712 / 77),
+            endPoint: UnitPoint(x: -5.69032 / 96, y: 35.8199 / 77)
+        )
+    }
 }
 
-// MARK: - Check Shape
+// MARK: - Figma Check Shape (fill path)
 
-/// 체크마크 path (좌측 → 하단 꼭짓점 → 우상단)
-private struct CheckShape: Shape {
+/// Figma SVG(viewBox 96×77)의 `<path d>` 를 좌표 그대로 옮긴 닫힌 도형.
+/// 절대좌표를 그대로 쓰고 마지막에 rect 크기로 스케일 → 어떤 frame에서도 동일 비율.
+private struct FigmaCheckShape: Shape {
     func path(in rect: CGRect) -> Path {
-        let w = rect.width
-        let h = rect.height
-        var path = Path()
-        path.move(to: CGPoint(x: w * 0.20, y: h * 0.52))
-        path.addLine(to: CGPoint(x: w * 0.42, y: h * 0.72))
-        path.addLine(to: CGPoint(x: w * 0.80, y: h * 0.30))
-        return path
+        var p = Path()
+        p.move(to: CGPoint(x: 70.8669, y: 4.87691))
+        p.addCurve(to: CGPoint(x: 84.3203, y: 0), control1: CGPoint(x: 75.5844, y: 1.59526), control2: CGPoint(x: 80, y: -7.08923e-06))
+        p.addCurve(to: CGPoint(x: 88.7109, y: 0.670899), control1: CGPoint(x: 86.1067, y: 0.109987), control2: CGPoint(x: 87.6235, y: 0.402059))
+        p.addCurve(to: CGPoint(x: 90.0498, y: 1.04688), control1: CGPoint(x: 89.2591, y: 0.80642), control2: CGPoint(x: 89.7118, y: 0.939318))
+        p.addCurve(to: CGPoint(x: 90.4727, y: 1.1875), control1: CGPoint(x: 90.2188, y: 1.10066), control2: CGPoint(x: 90.3608, y: 1.14839))
+        p.addCurve(to: CGPoint(x: 90.6191, y: 1.24023), control1: CGPoint(x: 90.5285, y: 1.20705), control2: CGPoint(x: 90.5782, y: 1.2253))
+        p.addCurve(to: CGPoint(x: 90.6748, y: 1.26074), control1: CGPoint(x: 90.6394, y: 1.24761), control2: CGPoint(x: 90.6583, y: 1.25461))
+        p.addCurve(to: CGPoint(x: 90.6982, y: 1.26953), control1: CGPoint(x: 90.6829, y: 1.26377), control2: CGPoint(x: 90.691, y: 1.26682))
+        p.addCurve(to: CGPoint(x: 90.709, y: 1.27344), control1: CGPoint(x: 90.7018, y: 1.27086), control2: CGPoint(x: 90.7057, y: 1.27219))
+        p.addLine(to: CGPoint(x: 90.7139, y: 1.27539))
+        p.addCurve(to: CGPoint(x: 88.5098, y: 7.10547), control1: CGPoint(x: 90.7145, y: 1.2807), control2: CGPoint(x: 90.6568, y: 1.44005))
+        p.addLine(to: CGPoint(x: 90.7188, y: 1.27734))
+        p.addCurve(to: CGPoint(x: 94.5977, y: 9.89063), control1: CGPoint(x: 94.1683, y: 2.5849), control2: CGPoint(x: 95.905, y: 6.44094))
+        p.addCurve(to: CGPoint(x: 85.9932, y: 13.7734), control1: CGPoint(x: 93.2914, y: 13.3373), control2: CGPoint(x: 89.4406, y: 15.0743))
+        p.addCurve(to: CGPoint(x: 86.002, y: 13.7774), control1: CGPoint(x: 85.996, y: 13.7746), control2: CGPoint(x: 85.9993, y: 13.7763))
+        p.addCurve(to: CGPoint(x: 86.0176, y: 13.7822), control1: CGPoint(x: 86.0073, y: 13.7793), control2: CGPoint(x: 86.013, y: 13.7805))
+        p.addCurve(to: CGPoint(x: 86.042, y: 13.792), control1: CGPoint(x: 86.027, y: 13.7858), control2: CGPoint(x: 86.0356, y: 13.7897))
+        p.addLine(to: CGPoint(x: 85.998, y: 13.7774))
+        p.addCurve(to: CGPoint(x: 85.5049, y: 13.6406), control1: CGPoint(x: 85.9105, y: 13.7495), control2: CGPoint(x: 85.7407, y: 13.699))
+        p.addCurve(to: CGPoint(x: 83.5, y: 13.335), control1: CGPoint(x: 85.0232, y: 13.5216), control2: CGPoint(x: 84.3186, y: 13.3854))
+        p.addCurve(to: CGPoint(x: 78.4958, y: 15.8437), control1: CGPoint(x: 81.8166, y: 13.2313), control2: CGPoint(x: 79.9348, y: 14.8428))
+        p.addCurve(to: CGPoint(x: 70.5876, y: 24.8281), control1: CGPoint(x: 77.0389, y: 16.8572), control2: CGPoint(x: 74.3117, y: 19.8217))
+        p.addCurve(to: CGPoint(x: 59.2097, y: 41.6338), control1: CGPoint(x: 67.0514, y: 29.5819), control2: CGPoint(x: 63.1061, y: 35.4913))
+        p.addCurve(to: CGPoint(x: 40.8552, y: 72.4101), control1: CGPoint(x: 51.4258, y: 53.9044), control2: CGPoint(x: 44.0477, y: 66.7648))
+        p.addCurve(to: CGPoint(x: 25.9352, y: 72.7969), control1: CGPoint(x: 37.5487, y: 78.2571), control2: CGPoint(x: 29.3925, y: 78.1929))
+        p.addCurve(to: CGPoint(x: 15.8386, y: 58.2715), control1: CGPoint(x: 23.7166, y: 69.3337), control2: CGPoint(x: 19.7922, y: 63.3936))
+        p.addCurve(to: CGPoint(x: 10.3942, y: 51.9307), control1: CGPoint(x: 13.8495, y: 55.6946), control2: CGPoint(x: 11.9746, y: 53.484))
+        p.addCurve(to: CGPoint(x: 0.730162, y: 47.3945), control1: CGPoint(x: 7.67969, y: 48.8603), control2: CGPoint(x: 3.17969, y: 50.3603))
+        p.addCurve(to: CGPoint(x: 3.64716, y: 38.4092), control1: CGPoint(x: -0.945403, y: 44.1079), control2: CGPoint(x: 0.360611, y: 40.085))
+        p.addCurve(to: CGPoint(x: 6.96259, y: 37.2099), control1: CGPoint(x: 4.11858, y: 38.1688), control2: CGPoint(x: 5.35525, y: 37.499))
+        p.addCurve(to: CGPoint(x: 11.197, y: 37.2588), control1: CGPoint(x: 8.55566, y: 36.9236), control2: CGPoint(x: 10.0199, y: 37.0777))
+        p.addCurve(to: CGPoint(x: 16.197, y: 39.3906), control1: CGPoint(x: 13.3072, y: 37.5835), control2: CGPoint(x: 15.0441, y: 38.5957))
+        p.addCurve(to: CGPoint(x: 19.7595, y: 42.4023), control1: CGPoint(x: 17.4527, y: 40.2565), control2: CGPoint(x: 18.6568, y: 41.3186))
+        p.addCurve(to: CGPoint(x: 26.4147, y: 50.1074), control1: CGPoint(x: 21.9698, y: 44.5748), control2: CGPoint(x: 24.2711, y: 47.3302))
+        p.addCurve(to: CGPoint(x: 32.9938, y: 59.2471), control1: CGPoint(x: 28.7407, y: 53.1208), control2: CGPoint(x: 31.0236, y: 56.352))
+        p.addCurve(to: CGPoint(x: 47.9284, y: 34.4775), control1: CGPoint(x: 36.8227, y: 52.6216), control2: CGPoint(x: 42.2596, y: 43.4139))
+        p.addCurve(to: CGPoint(x: 59.8679, y: 16.8535), control1: CGPoint(x: 51.9055, y: 28.2079), control2: CGPoint(x: 56.0499, y: 21.986))
+        p.addCurve(to: CGPoint(x: 70.8669, y: 4.87691), control1: CGPoint(x: 63.4978, y: 11.9737), control2: CGPoint(x: 67.3894, y: 7.29604))
+        p.closeSubpath()
+
+        return p.applying(CGAffineTransform(scaleX: rect.width / 96, y: rect.height / 77))
+    }
+}
+
+// MARK: - Check Spine (마스크용 중심선)
+
+/// 체크의 중심선(왼팔 끝 → 꼭짓점 → 우상단 끝). FigmaCheckShape와 동일 좌표계(96×77)에서
+/// 그린 뒤 같은 스케일을 적용해 정확히 겹친다. 굵은 stroke로 도형을 덮는 mask 용도라
+/// 픽셀 정밀할 필요는 없고 도형 두께를 충분히 커버하기만 하면 된다.
+private struct CheckSpine: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: 5, y: 42))                       // 왼팔 끝
+        p.addLine(to: CGPoint(x: 30, y: 66))                   // 꼭짓점(꺾이는 곳)
+        p.addQuadCurve(                                        // 우상단으로 부드럽게 휘는 긴 팔
+            to: CGPoint(x: 87, y: 7),
+            control: CGPoint(x: 58, y: 40)
+        )
+        return p.applying(CGAffineTransform(scaleX: rect.width / 96, y: rect.height / 77))
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/MultiSelectCalendarView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/MultiSelectCalendarView.swift
@@ -1,0 +1,233 @@
+//
+//  MultiSelectCalendarView.swift
+//  LivingStory-iOS
+//
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//  📅 다중 선택/하이라이트 SwiftUI 캘린더
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+//
+//  · 읽은 날(선택) = 갈색 채움 + 노란 글자, 탭으로 토글(다중선택)
+//  · 오늘 = 초록 채움 + 어두운 글자
+//  · MultiDatePicker로는 2톤 커스텀이 불가해 LazyVGrid로 직접 구현.
+//  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+import SwiftUI
+
+struct MultiSelectCalendarView: View {
+
+    /// 표시 중인 달 (더미: 2025년 4월)
+    @State private var month: Date = {
+        var c = DateComponents()
+        c.year = 2025; c.month = 4; c.day = 1
+        return Calendar(identifier: .gregorian).date(from: c) ?? Date()
+    }()
+
+    /// 책 읽은 날 — 더미 (데이터 표시 전용, 탭으로 바뀌지 않음)
+    private let readDays: Set<Int> = [8, 9, 10, 12, 14, 15]
+
+    /// 오늘(초록 강조) — 더미
+    private let todayDay = 20
+
+    @State private var showMonthPicker = false
+
+    private var cal: Calendar { Calendar(identifier: .gregorian) }
+    private let weekdays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8.83), count: 7)
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.bottom, 4)
+            weekdayRow
+            dateGrid
+        }
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture(minimumDistance: 24)
+                .onEnded { value in
+                    if value.translation.width < -40 {
+                        withAnimation(.easeInOut(duration: 0.2)) { changeMonth(by: 1) }
+                    } else if value.translation.width > 40 {
+                        withAnimation(.easeInOut(duration: 0.2)) { changeMonth(by: -1) }
+                    }
+                }
+        )
+        .sheet(isPresented: $showMonthPicker) {
+            MonthYearPickerSheet(month: $month)
+                .presentationDetents([.height(300)])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 4) {
+            Text(monthTitle)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(.white)
+            Button {
+                showMonthPicker = true
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(Color(hex: 0xFFCB24))
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 13)
+        .padding(.bottom, 3)
+    }
+
+    private var weekdayRow: some View {
+        LazyVGrid(columns: columns, spacing: 0) {
+            ForEach(weekdays, id: \.self) { day in
+                Text(day)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color(white: 0.92).opacity(0.3))
+                    .frame(height: 20)
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private var dateGrid: some View {
+        LazyVGrid(columns: columns, spacing: 7) {
+            ForEach(Array(monthDays.enumerated()), id: \.offset) { _, day in
+                if let day {
+                    dayCell(day)
+                } else {
+                    Color.clear.frame(height: 44)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 18)
+    }
+
+    private func dayCell(_ day: Int) -> some View {
+        let isToday = day == todayDay
+        let isRead = readDays.contains(day)
+
+        return Text("\(day)")
+            .font(.system(size: 20, weight: isToday ? .semibold : .regular))
+            .foregroundStyle(
+                isToday ? .white
+                : (isRead ? Color(hex: 0xFFCB24) : .white)
+            )
+            .frame(width: 44, height: 44)
+            .background {
+                if isToday {
+                    Circle().fill(
+                        LinearGradient(
+                            colors: [Color(hex: 0xBFEE68), Color(hex: 0xFFCB24)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                } else if isRead {
+                    Circle().fill(Color(hex: 0xFFCB24).opacity(0.16))
+                }
+            }
+    }
+
+    // MARK: - Logic
+
+    private var monthTitle: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: month)
+    }
+
+    /// 앞 빈칸(nil) + 1...말일
+    private var monthDays: [Int?] {
+        let comps = cal.dateComponents([.year, .month], from: month)
+        guard let first = cal.date(from: comps),
+              let range = cal.range(of: .day, in: .month, for: first) else { return [] }
+        let leading = cal.component(.weekday, from: first) - 1 // 1=Sun
+        return Array(repeating: nil, count: leading) + range.map { Optional($0) }
+    }
+
+    private func changeMonth(by value: Int) {
+        if let next = cal.date(byAdding: .month, value: value, to: month) {
+            month = next
+        }
+    }
+}
+
+// MARK: - 연/월 선택 시트
+
+private struct MonthYearPickerSheet: View {
+    @Binding var month: Date
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var year: Int
+    @State private var monthNum: Int
+
+    private let cal = Calendar(identifier: .gregorian)
+
+    init(month: Binding<Date>) {
+        _month = month
+        let cal = Calendar(identifier: .gregorian)
+        _year = State(initialValue: cal.component(.year, from: month.wrappedValue))
+        _monthNum = State(initialValue: cal.component(.month, from: month.wrappedValue))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
+                Button("완료") {
+                    apply()
+                    dismiss()
+                }
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Color(hex: 0xFFCB24))
+            }
+            .padding(16)
+
+            HStack(spacing: 0) {
+                Picker("연도", selection: $year) {
+                    ForEach(2020...2030, id: \.self) { Text("\($0)년").tag($0) }
+                }
+                .pickerStyle(.wheel)
+
+                Picker("월", selection: $monthNum) {
+                    ForEach(1...12, id: \.self) { Text("\($0)월").tag($0) }
+                }
+                .pickerStyle(.wheel)
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private func apply() {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = monthNum
+        comps.day = 1
+        if let date = cal.date(from: comps) { month = date }
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#Preview {
+    ZStack {
+        Color(red: 0.11, green: 0.11, blue: 0.12).ignoresSafeArea()
+        MultiSelectCalendarView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/PrimaryButton.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/PrimaryButton.swift
@@ -65,7 +65,6 @@ final class PrimaryButton: UIButton {
 // MARK: - SwiftUI Version
 
 struct PrimaryButtonSwiftUI: View {
-    @Environment(\.colorScheme) var scheme
     let title: String
     let action: () -> Void
 
@@ -73,7 +72,7 @@ struct PrimaryButtonSwiftUI: View {
         Button(action: action) {
             Capsule()
                 .frame(height: 52)
-                .foregroundStyle(scheme == .dark ? .clear : .black)
+                .foregroundStyle(.clear)
                 .glassEffect()
                 .overlay {
                     Text(title)

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/PrimaryButton.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/PrimaryButton.swift
@@ -76,7 +76,7 @@ struct PrimaryButtonSwiftUI: View {
                 .glassEffect()
                 .overlay {
                     Text(title)
-                        .font(.body2Medium)
+                        .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(.white)
                 }
         }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/ColorLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/ColorLiterals.swift
@@ -61,6 +61,13 @@ extension Color {
     }
 }
 
+// MARK: - Semantic Colors
+
+extension Color {
+    /// Backgrounds/Secondary — 앱 기본 다크 배경 (#1C1C1E). Figma 토큰명과 1:1.
+    static let backgroundSecondary = Color(hex: 0x1C1C1E)
+}
+
 // MARK: - Gradient Token
 
 /// 하나의 그라데이션 토큰. SwiftUI(`linear`)와 UIKit(`makeLayer()`)에서 동일한 stop으로 사용.

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
@@ -99,6 +99,22 @@ extension UIFont {
     /// 13 Regular · LS -0.6% · LH 18px
     static let footnoteRegular = pretendard(.footnote, size: 13, weight: .regular)
 
+    // ───── App Custom (Figma 타입스케일 외 · 특정 화면 전용) ─────
+    /// 66 SemiBold — 나이 설정 값
+    static let display1SemiBold = pretendard(.largeTitle, size: 66, weight: .semibold)
+    /// 28 SemiBold — 나이 단위(세)
+    static let display2SemiBold = pretendard(.title1, size: 28, weight: .semibold)
+    /// 22 Regular — 나이 접두(만)
+    static let display3Regular = pretendard(.title1, size: 22, weight: .regular)
+    /// 28 Bold — 통계 타이틀 (Figma Title1/Emphasized)
+    static let title1Emphasized = pretendard(.title1, size: 28, weight: .bold)
+    /// 13 SemiBold — 배지 (Figma Footnote/Emphasized)
+    static let footnoteEmphasized = pretendard(.footnote, size: 13, weight: .semibold)
+    /// 17 Medium — 글래스 버튼
+    static let buttonMedium = pretendard(.body, size: 17, weight: .medium)
+    /// 15 Medium — 글래스 필
+    static let buttonSmallMedium = pretendard(.subheadline, size: 15, weight: .medium)
+
     // MARK: Helper
     private static func pretendard(_ textStyle: UIFont.TextStyle, size: CGFloat, weight: UIFont.Weight) -> UIFont {
         let base = UIFont(name: pretendardName(weight), size: size)!
@@ -149,6 +165,22 @@ extension Font {
 
     // ───── Footnote ─────
     static let footnoteRegular = pretendard(13, .regular, .footnote)
+
+    // ───── App Custom (Figma 타입스케일 외 · 특정 화면 전용) ─────
+    /// 66 SemiBold — 나이 설정 값
+    static let display1SemiBold = pretendard(66, .semibold, .largeTitle)
+    /// 28 SemiBold — 나이 단위(세)
+    static let display2SemiBold = pretendard(28, .semibold, .title)
+    /// 22 Regular — 나이 접두(만)
+    static let display3Regular = pretendard(22, .regular, .title)
+    /// 28 Bold — 통계 타이틀 (Figma Title1/Emphasized)
+    static let title1Emphasized = pretendard(28, .bold, .title)
+    /// 13 SemiBold — 배지 (Figma Footnote/Emphasized)
+    static let footnoteEmphasized = pretendard(13, .semibold, .footnote)
+    /// 17 Medium — 글래스 버튼
+    static let buttonMedium = pretendard(17, .medium, .body)
+    /// 15 Medium — 글래스 필
+    static let buttonSmallMedium = pretendard(15, .medium, .subheadline)
 
     // MARK: Helper
     private static func pretendard(_ size: CGFloat, _ weight: Font.Weight, _ relativeTo: Font.TextStyle) -> Font {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -46,6 +46,7 @@ enum StringLiterals {
         static let setupButton = "책 환경 세팅하기"
         static let resultTitle = "읽은 책"
         static let homeButton = "홈으로"
+        static let conversationTitle = "대화 나누기"
         static let readingDoneTitle = "책 읽기 완료!"
         static let talkWithChild = "아이와 대화 나누기"
         static let readAnotherBook = "다른 책 읽기"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -32,8 +32,8 @@ enum StringLiterals {
     enum Reading {
         static let settingTitle = "환경 세팅중..."
         static let settingSubtitle = "몇 분 소요될 수 있습니다."
-        static let settingDoneTitle = "책 분위기에 맞게 환경이 세팅 됐어요!"
-        static let settingDoneSubtitle = "이제 책을 더 재밌게 읽으세요!"
+        static let settingDoneTitle = "환경 세팅 완료!"
+        static let settingDoneSubtitle = "이제 재밌게 읽으세요!"
         static let stopSettingAlert = "환경 세팅을 전체 중단할까요?"
         static let stopReadingAlert = "책 읽기를 그만할까요?"
         static let close = "닫기"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -51,6 +51,13 @@ enum StringLiterals {
         static let talkWithChild = "아이와 대화 나누기"
         static let readAnotherBook = "다른 책 읽기"
         static let finishReading = "책 읽기 종료"
+        // 에러 알림 · 독서 환경 컨트롤
+        static let retry = "재시도"
+        static let lightingTitle = "조명"
+        static let musicTitle = "음악"
+        static let brightness = "밝기"
+        static let volume = "볼륨"
+        static let adjust = "조정"
         static func todayBookCount(_ count: Int) -> String { "오늘 아이에게\n책을 \(count)번 읽어줬어요!" }
         static func todayReadBooks(_ count: Int) -> String { "오늘 \(count)권의 책을\n읽어줬어요!" }
     }
@@ -127,6 +134,8 @@ enum StringLiterals {
         static let childAgeTitle = "아이 나이 설정"
         static let childAgeHeadline = "아이의 나이를 알려주세요"
         static let childAgeSubtitle = "나이에 맞는 대화 주제를 추천해드려요"
+        static let agePrefix = "만"
+        static let ageUnit = "세"
 
         static let notificationTitle = "알림 시간 설정"
         static let notificationHeadline = "몇시에 책을 읽어주실 건가요?"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -52,6 +52,7 @@ enum StringLiterals {
         static let readAnotherBook = "다른 책 읽기"
         static let finishReading = "책 읽기 종료"
         static func todayBookCount(_ count: Int) -> String { "오늘 아이에게\n책을 \(count)번 읽어줬어요!" }
+        static func todayReadBooks(_ count: Int) -> String { "오늘 \(count)권의 책을\n읽어줬어요!" }
     }
 
     enum Book {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -111,6 +111,33 @@ enum StringLiterals {
         static let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
     }
 
+    enum Setting {
+        static let title = "설정"
+        static let childInfoSection = "아이 정보"
+        static let childAge = "아이 나이"
+        static let notificationSection = "알림"
+        static let notificationTime = "알림 시간"
+        static let environmentSection = "환경 세팅"
+        static let home = "집"
+        static let appInfoSection = "앱 정보"
+        static let version = "버전"
+        static let privacy = "개인정보처리방침"
+        static let done = "완료"
+
+        static let childAgeTitle = "아이 나이 설정"
+        static let childAgeHeadline = "아이의 나이를 알려주세요"
+        static let childAgeSubtitle = "나이에 맞는 대화 주제를 추천해드려요"
+
+        static let notificationTitle = "알림 시간 설정"
+        static let notificationHeadline = "몇시에 책을 읽어주실 건가요?"
+        static let notificationSubtitle = "매일 설정한 시간에 알람을 드릴게요"
+        static let notificationToggle = "알림 설정"
+
+        static let homeTitle = "집 선택"
+        static let homeHeadline = "어디에서 사용할 건가요?"
+        static let homeSubtitle = "나루를 사용할 집을 선택해주세요"
+    }
+
     enum Onboarding {
         static let coachMark1 = "책 읽기 시작하기를 통해 스캔한 책에 맞는 분위기로 조명과 스피커를 세팅할 수 있어요"
         static let coachMark2 = "책 읽기에 사용할 장치를 설정할 수 있어요"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -94,6 +94,9 @@ enum StringLiterals {
 
     enum My {
         static let title = "마이"
+        static let summaryTitle = "내 독서 요약"
+        static let monthlyReadIntro = "이번 달에 책을 이만큼 읽어줬어요!"
+        static let totalReadBooks = "총 읽어준 책"
         static let monthlyBookCount = "이번 달 읽어준 횟수"
         static let totalBookCount = "총 읽은 책 수"
         static let totalReadingTime = "총 읽은 시간"

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -46,6 +46,10 @@ enum StringLiterals {
         static let setupButton = "책 환경 세팅하기"
         static let resultTitle = "읽은 책"
         static let homeButton = "홈으로"
+        static let readingDoneTitle = "책 읽기 완료!"
+        static let talkWithChild = "아이와 대화 나누기"
+        static let readAnotherBook = "다른 책 읽기"
+        static let finishReading = "책 읽기 종료"
         static func todayBookCount(_ count: Int) -> String { "오늘 아이에게\n책을 \(count)번 읽어줬어요!" }
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/SymbolLiterals.swift
@@ -36,6 +36,7 @@ enum SymbolLiterals: String {
     case book = "book.fill"
     case person = "person.fill"
     case settings = "gearshape"
+    case settingsFill = "gearshape.fill"
 
     // MARK: - Navigation
 
@@ -77,6 +78,7 @@ enum SymbolLiterals: String {
     case calendar = "calendar"
     case books = "books.vertical.fill"
     case clock = "clock"
+    case flame = "flame.fill"
 
     // MARK: - Reading
 
@@ -88,6 +90,13 @@ enum SymbolLiterals: String {
     case timer = "timer"
     case moon = "moon.fill"
     case sun = "sun.max.fill"
+    case waveform = "waveform"
+    case sliderHorizontal = "slider.horizontal.3"
+
+    // MARK: - Settings
+
+    case childHands = "figure.and.child.holdinghands"
+    case alarm = "alarm.fill"
 }
 
 // MARK: - SwiftUI Extension

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -1,0 +1,113 @@
+//
+//  ConversationView.swift
+//  LivingStory-iOS
+//
+//  아이와 대화 나누기 — 책에 대한 대화 주제 리스트
+//  (책 읽기 완료 화면의 '아이와 대화 나누기'에서 진입)
+//
+
+import SwiftUI
+
+struct ConversationView: View {
+    let coordinator: AppCoordinator
+    let bookTitle: String
+    let conversations: [ConversationProfile]
+
+    var body: some View {
+        ZStack {
+            Color(hex: 0x1C1C1E)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                header
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Image(.conversation)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 26)
+                            Text(StringLiterals.Reading.conversationPrompt)
+                                .font(.title2Emphasized)
+                                .foregroundStyle(.white)
+                        }
+
+                        VStack(spacing: 16) {
+                            ForEach(conversations) { item in
+                                ConversationCard(
+                                    question: item.question,
+                                    effect: item.effect
+                                )
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        ZStack {
+            Text(bookTitle)
+                .font(.headlineRegular)
+                .foregroundStyle(.white)
+                .lineLimit(1)
+
+            HStack {
+                Button {
+                    coordinator.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 44, height: 44)
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 10)
+    }
+}
+
+// MARK: - Conversation Card
+
+private struct ConversationCard: View {
+    let question: String
+    let effect: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CharWrappingText(text: question, font: .bodyLargeMedium, color: .gray10)
+            CharWrappingText(
+                text: effect,
+                font: .calloutRegular,
+                color: .gray40
+            )
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.yellow90)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -80,7 +80,7 @@ private struct ConversationAccordionCard: View {
                 numberBadge
                 Text(effect)
                     .font(.system(size: 16))
-                    .foregroundStyle(Color(hex: 0xBFEE68))
+                    .foregroundStyle(.green0)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -97,7 +97,8 @@ private struct ConversationAccordionCard: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 30))
+        // Backgrounds/Tertiary (iOS 시스템색)
+        .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 30))
         .contentShape(RoundedRectangle(cornerRadius: 30))
         .onTapGesture(perform: onTap)
     }
@@ -114,7 +115,7 @@ private struct ConversationAccordionCard: View {
         .padding(.vertical, 6)
         .background(
             LinearGradient(
-                colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                colors: [.yellow20, .green0],
                 startPoint: .leading,
                 endPoint: .trailing
             ),

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -2,7 +2,7 @@
 //  ConversationView.swift
 //  LivingStory-iOS
 //
-//  아이와 대화 나누기 — 책에 대한 대화 주제 리스트
+//  아이와 대화 나누기 — 책에 대한 대화 주제 아코디언 리스트
 //  (책 읽기 완료 화면의 '아이와 대화 나누기'에서 진입)
 //
 
@@ -10,8 +10,10 @@ import SwiftUI
 
 struct ConversationView: View {
     let coordinator: AppCoordinator
-    let bookTitle: String
     let conversations: [ConversationProfile]
+
+    /// 펼쳐진 카드 인덱스 (한 번에 하나만, 첫 카드 기본 펼침)
+    @State private var expandedIndex: Int? = 0
 
     var body: some View {
         ZStack {
@@ -22,28 +24,22 @@ struct ConversationView: View {
                 header
 
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 20) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Image(.conversation)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 26)
-                            Text(StringLiterals.Reading.conversationPrompt)
-                                .font(.title2Emphasized)
-                                .foregroundStyle(.white)
-                        }
-
-                        VStack(spacing: 16) {
-                            ForEach(conversations) { item in
-                                ConversationCard(
-                                    question: item.question,
-                                    effect: item.effect
-                                )
+                    VStack(spacing: 12) {
+                        ForEach(Array(conversations.enumerated()), id: \.element.id) { index, item in
+                            ConversationAccordionCard(
+                                index: index,
+                                effect: item.effect,
+                                question: item.question,
+                                isExpanded: expandedIndex == index
+                            ) {
+                                withAnimation(.easeInOut(duration: 0.25)) {
+                                    expandedIndex = (expandedIndex == index) ? nil : index
+                                }
                             }
                         }
                     }
                     .padding(.horizontal, 20)
-                    .padding(.top, 12)
+                    .padding(.top, 4)
                 }
             }
         }
@@ -56,47 +52,83 @@ struct ConversationView: View {
 
     private var header: some View {
         ZStack {
-            Text(bookTitle)
+            Text(StringLiterals.Reading.conversationTitle)
                 .font(.headlineRegular)
                 .foregroundStyle(.white)
-                .lineLimit(1)
 
             HStack {
                 Button {
                     coordinator.pop()
                 } label: {
                     Image(systemName: "chevron.left")
-                        .font(.system(size: 17, weight: .semibold))
+                        .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(.white)
                         .frame(width: 44, height: 44)
+                        .glassEffect(.regular, in: Circle())
                 }
                 Spacer()
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 16)
         .padding(.vertical, 10)
     }
 }
 
-// MARK: - Conversation Card
+// MARK: - Accordion Card
 
-private struct ConversationCard: View {
-    let question: String
+private struct ConversationAccordionCard: View {
+    let index: Int
     let effect: String
+    let question: String
+    let isExpanded: Bool
+    let onTap: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            CharWrappingText(text: question, font: .bodyLargeMedium, color: .gray10)
-            CharWrappingText(
-                text: effect,
-                font: .calloutRegular,
-                color: .gray40
-            )
+        VStack(alignment: .leading, spacing: 20) {
+            HStack(spacing: 12) {
+                numberBadge
+                Text(effect)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color(hex: 0xBFEE68))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            if isExpanded {
+                Text(question)
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(.white)
+                    .lineSpacing(8)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 4)
+                    .padding(.bottom, 6)
+            }
         }
-        .padding(14)
+        .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.yellow90)
-        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 30))
+        .contentShape(RoundedRectangle(cornerRadius: 30))
+        .onTapGesture(perform: onTap)
+    }
+
+    private var numberBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "bubble.left.fill")
+                .font(.system(size: 11))
+            Text(String(format: "%02d", index + 1))
+                .font(.system(size: 13, weight: .semibold))
+        }
+        .foregroundStyle(Color(hex: 0x121212))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            LinearGradient(
+                colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                startPoint: .leading,
+                endPoint: .trailing
+            ),
+            in: Capsule()
+        )
     }
 }
 
@@ -111,3 +143,16 @@ private extension Color {
         )
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        ConversationView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            conversations: ReadingEnvironment.mock.toConversationProfiles()
+        )
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -17,7 +17,7 @@ struct ConversationView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E)
+            Color.backgroundSecondary
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
@@ -104,7 +104,7 @@ private struct ConversationAccordionCard: View {
 
     private var numberBadge: some View {
         HStack(spacing: 4) {
-            Image(systemName: "bubble.left.fill")
+            Image(systemName: "ellipsis.message.fill")
                 .font(.system(size: 11))
             Text(String(format: "%02d", index + 1))
                 .font(.system(size: 13, weight: .semibold))

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -21,8 +21,6 @@ struct ConversationView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                header
-
                 ScrollView {
                     VStack(spacing: 12) {
                         ForEach(Array(conversations.enumerated()), id: \.element.id) { index, item in
@@ -44,33 +42,26 @@ struct ConversationView: View {
             }
         }
         .preferredColorScheme(.dark)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden, for: .navigationBar)
-    }
-
-    // MARK: - Header
-
-    private var header: some View {
-        ZStack {
-            Text(StringLiterals.Reading.conversationTitle)
-                .font(.headlineRegular)
-                .foregroundStyle(.white)
-
-            HStack {
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
                 Button {
                     coordinator.pop()
                 } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(.white)
-                        .frame(width: 44, height: 44)
-                        .glassEffect(.regular, in: Circle())
                 }
-                Spacer()
+            }
+            // 제목 색을 시스템 네비바(앱 라이트 고정→검정)에 맡기지 않고 흰색 콘텐츠로 직접 렌더
+            ToolbarItem(placement: .principal) {
+                Text(StringLiterals.Reading.conversationTitle)
+                    .font(.headline)
+                    .foregroundStyle(.white)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -50,7 +50,7 @@ struct ConversationView: View {
                 Button {
                     coordinator.pop()
                 } label: {
-                    Image(systemName: "chevron.left")
+                    Image(.back)
                         .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(.white)
                 }
@@ -105,7 +105,7 @@ private struct ConversationAccordionCard: View {
 
     private var numberBadge: some View {
         HStack(spacing: 4) {
-            Image(systemName: "ellipsis.message.fill")
+            Image(.conversation)
                 .font(.system(size: 11))
             Text(String(format: "%02d", index + 1))
                 .font(.footnoteEmphasized)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -79,7 +79,7 @@ private struct ConversationAccordionCard: View {
             HStack(spacing: 12) {
                 numberBadge
                 Text(effect)
-                    .font(.system(size: 16))
+                    .font(.calloutRegular)
                     .foregroundStyle(.green0)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -87,7 +87,7 @@ private struct ConversationAccordionCard: View {
 
             if isExpanded {
                 Text(question)
-                    .font(.system(size: 24, weight: .medium))
+                    .font(.headlineMedium)
                     .foregroundStyle(.white)
                     .lineSpacing(8)
                     .fixedSize(horizontal: false, vertical: true)
@@ -108,7 +108,7 @@ private struct ConversationAccordionCard: View {
             Image(systemName: "ellipsis.message.fill")
                 .font(.system(size: 11))
             Text(String(format: "%02d", index + 1))
-                .font(.system(size: 13, weight: .semibold))
+                .font(.footnoteEmphasized)
         }
         .foregroundStyle(Color(hex: 0x121212))
         .padding(.horizontal, 10)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -18,16 +18,25 @@ struct ReadingView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-
             if viewModel.state == .reading {
                 readingDoneLayout
             } else {
                 settingLayout
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(viewModel.book.bookTitle)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                    // 중단 시 체크 전환 인터랙션 동안엔 제목 숨김 (페이드 함께)
+                    .opacity(isFinishing ? 0 : 1)
+            }
+        }
         .background { pulseBackground }
         .overlay {
             if isFinishing {
@@ -89,17 +98,6 @@ struct ReadingView: View {
 
     // MARK: - Layouts
 
-    /// 커스텀 헤더 (책 제목) — 전역 네비바를 숨기므로 navigationTitle 대신 직접 표시
-    private var header: some View {
-        Text(viewModel.book.bookTitle)
-            .font(.headlineRegular)
-            .foregroundStyle(.white)
-            .lineLimit(1)
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 13)
-    }
-
     /// 세팅 중 (·error): 중앙 아이콘 + 문구 + '환경 세팅 중지'
     private var settingLayout: some View {
         VStack {
@@ -145,10 +143,10 @@ struct ReadingView: View {
 
             VStack(spacing: 6) {
                 Text(StringLiterals.Reading.settingTitle)
-                    .font(.bodyRegular)
+                    .font(.body1Regular)
                     .foregroundStyle(.white)
                 Text(StringLiterals.Reading.settingSubtitle)
-                    .font(.subheadlineRegular)
+                    .font(.body2Regular)
                     .foregroundStyle(.white.opacity(0.5))
                     .multilineTextAlignment(.center)
             }
@@ -171,10 +169,10 @@ struct ReadingView: View {
 
             VStack(spacing: 12) {
                 Text(StringLiterals.Reading.settingDoneTitle)
-                    .font(.system(size: 20))
+                    .font(.body1Regular)
                     .foregroundStyle(.white)
                 Text(StringLiterals.Reading.settingDoneSubtitle)
-                    .font(.system(size: 18))
+                    .font(.body2Regular)
                     .foregroundStyle(.white.opacity(0.5))
             }
             .multilineTextAlignment(.center)
@@ -295,7 +293,7 @@ private struct EnvControlRow<Leading: View>: View {
                     Image(systemName: systemImage)
                         .font(.system(size: 15, weight: .semibold))
                     Text(title)
-                        .font(.system(size: 18, weight: .medium))
+                        .font(.body2Medium)
                 }
                 .foregroundStyle(.white)
 
@@ -310,11 +308,11 @@ private struct EnvControlRow<Leading: View>: View {
                 VStack(spacing: 0) {
                     HStack {
                         Text(valueLabel)
-                            .font(.system(size: 14))
+                            .font(.labelRegular)
                             .foregroundStyle(.white.opacity(0.7))
                         Spacer()
                         Text(percentText)
-                            .font(.system(size: 14, weight: .medium))
+                            .font(.labelMedium)
                             .foregroundStyle(.white)
                     }
 
@@ -332,7 +330,7 @@ private struct AdjustPill: View {
             Image(systemName: "slider.horizontal.3")
                 .font(.system(size: 11, weight: .semibold))
             Text("조정")
-                .font(.system(size: 14, weight: .medium))
+                .font(.labelMedium)
         }
         .foregroundStyle(.white)
         .padding(.horizontal, 14)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -14,27 +14,33 @@ struct ReadingView: View {
 
     @State private var isPulsing = false
     @State private var showStopAlert = false
-    @State private var showColorWheel = false
-    
+    @State private var isFinishing = false
+
     var body: some View {
-        VStack {
-            Spacer()
-            statusContent
+        VStack(spacing: 0) {
+            header
+
             if viewModel.state == .reading {
-                controlPanel
-                    .padding(.horizontal, 20)
-                    .padding(.top, 24)
+                readingDoneLayout
+            } else {
+                settingLayout
             }
-            Spacer()
-            actionButton
-                .padding(.horizontal, 20)
         }
-        .navigationTitle(viewModel.book.bookTitle)
-        .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
         .background { pulseBackground }
+        .overlay {
+            if isFinishing {
+                CheckmarkTransitionView {
+                    coordinator.showStopReading(
+                        bookTitle: viewModel.book.bookTitle,
+                        conversations: viewModel.conversations
+                    )
+                }
+                .transition(.opacity)
+            }
+        }
         .preferredColorScheme(.dark)
-        .toolbarColorScheme(.dark, for: .navigationBar)
         .onAppear {
             withAnimation(
                 .easeInOut(duration: 2.5)
@@ -53,7 +59,8 @@ struct ReadingView: View {
                 if viewModel.state == .setting {
                     coordinator.pop()
                 } else {
-                    coordinator.showStopReading(bookTitle: viewModel.book.bookTitle, conversations: viewModel.conversations)
+                    // 독서 종료: 체크 전환 인터랙션 후 StopReadingView로 이동
+                    withAnimation(.easeInOut(duration: 0.25)) { isFinishing = true }
                 }
             }
         } message: {
@@ -79,31 +86,101 @@ struct ReadingView: View {
             await viewModel.startSetup()
         }
     }
-    
-    // MARK: - Subviews
-    
-    private var statusContent: some View {
+
+    // MARK: - Layouts
+
+    /// 커스텀 헤더 (책 제목) — 전역 네비바를 숨기므로 navigationTitle 대신 직접 표시
+    private var header: some View {
+        Text(viewModel.book.bookTitle)
+            .font(.headlineRegular)
+            .foregroundStyle(.white)
+            .lineLimit(1)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 13)
+    }
+
+    /// 세팅 중 (·error): 중앙 아이콘 + 문구 + '환경 세팅 중지'
+    private var settingLayout: some View {
+        VStack {
+            Spacer()
+            settingStatus
+            Spacer()
+            actionButton
+                .padding(.horizontal, 20)
+        }
+    }
+
+    /// 세팅 완료(독서 중): 아이콘 + '환경 세팅 완료!' + 컨트롤 카드 + '그만 읽기'
+    private var readingDoneLayout: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 24)
+
+            doneStatus
+
+            Spacer().frame(height: 52)
+
+            ControlCard(
+                lightingColor: lightingColor,
+                brightness: viewModel.lightingConfig?.brightness ?? 50
+            )
+            .padding(.horizontal, 20)
+
+            Spacer()
+
+            actionButton
+                .padding(.horizontal, 20)
+        }
+    }
+
+    // MARK: - Status Content
+
+    private var settingStatus: some View {
         VStack(spacing: 28) {
-            Image(viewModel.state == .setting ? .home : .musicNoteHouse)
+            Image(.home)
                 .resizable()
                 .scaledToFit()
-                .foregroundStyle(.white)
                 .frame(height: 79)
-                .id(viewModel.state)
-            
+                .foregroundStyle(.white.opacity(0.22))
+
             VStack(spacing: 6) {
-                Text(viewModel.state == .setting ? StringLiterals.Reading.settingTitle : StringLiterals.Reading.settingDoneTitle)
-                    .font(.body2Regular)
+                Text(StringLiterals.Reading.settingTitle)
+                    .font(.bodyRegular)
                     .foregroundStyle(.white)
-                Text(viewModel.state == .setting ? StringLiterals.Reading.settingSubtitle : StringLiterals.Reading.settingDoneSubtitle)
-                    .font(.subheadline)
-                    .foregroundStyle(.white)
-                    .opacity(0.5)
+                Text(StringLiterals.Reading.settingSubtitle)
+                    .font(.subheadlineRegular)
+                    .foregroundStyle(.white.opacity(0.5))
                     .multilineTextAlignment(.center)
             }
         }
     }
-    
+
+    private var doneStatus: some View {
+        VStack(spacing: 28) {
+            Image(.musicNoteHouse)
+                .resizable()
+                .scaledToFit()
+                .frame(height: 72)
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [Color(hex: 0x92CFB1), Color(hex: 0xBFEE68), Color(hex: 0xFFCB24)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+
+            VStack(spacing: 12) {
+                Text(StringLiterals.Reading.settingDoneTitle)
+                    .font(.system(size: 20))
+                    .foregroundStyle(.white)
+                Text(StringLiterals.Reading.settingDoneSubtitle)
+                    .font(.system(size: 18))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            .multilineTextAlignment(.center)
+        }
+    }
+
     private var actionButton: some View {
         PrimaryButtonSwiftUI(
             title: viewModel.state == .setting ? StringLiterals.Reading.stopSettingButton : StringLiterals.Reading.stopReadingButton
@@ -112,7 +189,9 @@ struct ReadingView: View {
         }
         .environment(\.colorScheme, .dark)
     }
-    
+
+    // MARK: - Helpers
+
     private var lightingColor: Color {
         guard let config = viewModel.lightingConfig else {
             return .yellow0
@@ -123,196 +202,6 @@ struct ReadingView: View {
             brightness: Double(config.brightness) / 100.0
         )
     }
-    
-    // MARK: - Control Panel
-    private var controlPanel: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            // 반응 로그
-            HStack {
-                Text(viewModel.lastAction ?? "대기")
-                    .font(.caption)
-                    .foregroundStyle(.white.opacity(0.7))
-                Spacer()
-                if let ms = viewModel.lastLatencyMs {
-                    Text("\(ms)ms")
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.white.opacity(0.9))
-                }
-            }
-
-            // 반응시간 통계 (latencyHistory 있을 때)
-            if let avg = viewModel.avgLatencyMs,
-               let minV = viewModel.minLatencyMs,
-               let maxV = viewModel.maxLatencyMs {
-                HStack(spacing: 14) {
-                    latencyStat("평균", value: avg)
-                    latencyStat("최소", value: minV)
-                    latencyStat("최대", value: maxV)
-                    Spacer()
-                    Button {
-                        viewModel.clearLatencyHistory()
-                    } label: {
-                        Image(systemName: "arrow.counterclockwise")
-                            .font(.caption)
-                            .foregroundStyle(.white.opacity(0.5))
-                    }
-                }
-                .font(.caption2.monospaced())
-                .foregroundStyle(.white.opacity(0.6))
-            }
-
-            // 볼륨
-            HStack(spacing: 10) {
-                Image(systemName: "speaker.wave.1.fill")
-                    .foregroundStyle(.white)
-                Slider(
-                    value: Binding(
-                        get: { viewModel.volume },
-                        set: { viewModel.setVolume($0) }
-                    ),
-                    in: 0...1
-                )
-                .tint(.white)
-                Image(systemName: "speaker.wave.3.fill")
-                    .foregroundStyle(.white)
-            }
-            
-            // 음악 카테고리 (가로 스크롤 10개 버튼)
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(MusicCategory.allCases, id: \.self) { category in
-                        Button {
-                            viewModel.changeMusic(to: category)
-                        } label: {
-                            Text(category.rawValue)
-                                .font(.caption)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 7)
-                                .background(
-                                    viewModel.musicCategory == category
-                                    ? Color.white.opacity(0.35)
-                                    : Color.white.opacity(0.12)
-                                )
-                                .foregroundStyle(.white)
-                                .clipShape(Capsule())
-                        }
-                    }
-                }
-            }
-
-            // 조명 프리셋 팔레트 + 커스텀 색상환
-            HStack(spacing: 10) {
-                // Gemini 추천 버튼 (있을 때만)
-                if let geminiConfig = viewModel.geminiRecommendedLighting {
-                    Button {
-                        viewModel.applyGeminiRecommended()
-                    } label: {
-                        VStack(spacing: 4) {
-                            Circle()
-                                .fill(
-                                    Color(
-                                        hue: Double(geminiConfig.hue) / 360.0,
-                                        saturation: Double(geminiConfig.saturation) / 100.0,
-                                        brightness: Double(geminiConfig.brightness) / 100.0
-                                    )
-                                )
-                                .frame(width: 32, height: 32)
-                                .overlay(
-                                    Circle()
-                                        .stroke(.yellow, lineWidth: 2)
-                                )
-                            Text("AI")
-                                .font(.caption2)
-                                .foregroundStyle(.white)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-
-                ForEach(LightingPreset.allCases, id: \.self) { preset in
-                    Button {
-                        viewModel.applyPreset(preset)
-                    } label: {
-                        VStack(spacing: 4) {
-                            Circle()
-                                .fill(preset.previewColor)
-                                .frame(width: 32, height: 32)
-                                .overlay(
-                                    Circle()
-                                        .stroke(.white.opacity(0.4), lineWidth: 1)
-                                )
-                            Text(preset.rawValue)
-                                .font(.caption2)
-                                .foregroundStyle(.white)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                }
-
-                // 커스텀 원형 색상환 (탭 시 sheet로 열림)
-                Button {
-                    showColorWheel = true
-                } label: {
-                    VStack(spacing: 4) {
-                        Circle()
-                            .fill(
-                                AngularGradient(
-                                    colors: [.red, .yellow, .green, .cyan, .blue, .purple, .red],
-                                    center: .center
-                                )
-                            )
-                            .frame(width: 32, height: 32)
-                            .overlay(
-                                Circle()
-                                    .stroke(.white.opacity(0.4), lineWidth: 1)
-                            )
-                        Text("커스텀")
-                            .font(.caption2)
-                            .foregroundStyle(.white)
-                    }
-                }
-                .frame(maxWidth: .infinity)
-            }
-            .sheet(isPresented: $showColorWheel) {
-                ColorWheelSheet(viewModel: viewModel)
-                    .presentationDetents([.medium, .large])
-            }
-
-            // 밝기 (손 뗄 때 즉시 전송)
-            HStack(spacing: 10) {
-                Image(systemName: "sun.min.fill")
-                    .foregroundStyle(.white)
-                Slider(
-                    value: Binding(
-                        get: { Double(viewModel.lightingConfig?.brightness ?? 80) },
-                        set: { viewModel.updateLighting(brightness: Int($0)) }
-                    ),
-                    in: 10...100,
-                    onEditingChanged: { isEditing in
-                        if !isEditing {
-                            viewModel.commitLighting()  // 손 뗐을 때 즉시 전송
-                        }
-                    }
-                )
-                .tint(.white)
-                Image(systemName: "sun.max.fill")
-                    .foregroundStyle(.white)
-            }
-        }
-        .padding(16)
-        .background(.white.opacity(0.08))
-        .clipShape(RoundedRectangle(cornerRadius: 14))
-    }
-
-    private func latencyStat(_ label: String, value: Int) -> some View {
-        HStack(spacing: 4) {
-            Text(label)
-                .foregroundStyle(.white.opacity(0.4))
-            Text("\(value)ms")
-                .foregroundStyle(.white.opacity(0.85))
-        }
-    }
-
 
     private var pulseBackground: some View {
         ZStack {
@@ -338,130 +227,195 @@ struct ReadingView: View {
     }
 }
 
-// MARK: - LightingPreset Preview Color
+// MARK: - Control Card (조명 / 음악)
 
-extension LightingPreset {
-    var previewColor: Color {
-        let c = config
-        return Color(
-            hue: Double(c.hue) / 360.0,
-            saturation: Double(c.saturation) / 100.0,
-            brightness: Double(c.brightness) / 100.0
+private struct ControlCard: View {
+    let lightingColor: Color
+    let brightness: Int
+
+    var body: some View {
+        VStack(spacing: 16) {
+            EnvControlRow(
+                systemImage: "lightbulb.fill",
+                title: "조명",
+                valueLabel: "밝기",
+                percentText: "\(brightness)%",
+                fraction: Double(brightness) / 100.0
+            ) {
+                Circle()
+                    .fill(lightingColor)
+                    .frame(width: 56, height: 56)
+            }
+
+            Rectangle()
+                .fill(Color.white.opacity(0.08))
+                .frame(height: 1)
+                .padding(.horizontal, 8)
+
+            EnvControlRow(
+                systemImage: "speaker.wave.2.fill",
+                title: "음악",
+                valueLabel: "볼륨",
+                percentText: "50%",          // 추천 볼륨 데이터 없음 → 고정 더미
+                fraction: 0.5
+            ) {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(
+                        LinearGradient(
+                            colors: [Color(hex: 0xCCBFE5), Color(hex: 0x6E5BB8)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 56, height: 56)
+                    .overlay {
+                        Image(systemName: "waveform")
+                            .font(.system(size: 20, weight: .semibold))
+                            .foregroundStyle(.white)
+                    }
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(Color(hex: 0x1C1C1E), in: RoundedRectangle(cornerRadius: 24))
+    }
+}
+
+private struct EnvControlRow<Leading: View>: View {
+    let systemImage: String
+    let title: String
+    let valueLabel: String
+    let percentText: String
+    let fraction: Double
+    @ViewBuilder let leading: () -> Leading
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                HStack(spacing: 6) {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 15, weight: .semibold))
+                    Text(title)
+                        .font(.system(size: 18, weight: .medium))
+                }
+                .foregroundStyle(.white)
+
+                Spacer()
+
+                AdjustPill()
+            }
+
+            HStack(spacing: 20) {
+                leading()
+
+                VStack(spacing: 0) {
+                    HStack {
+                        Text(valueLabel)
+                            .font(.system(size: 14))
+                            .foregroundStyle(.white.opacity(0.7))
+                        Spacer()
+                        Text(percentText)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.white)
+                    }
+
+                    EnvSlider(fraction: fraction)
+                }
+            }
+        }
+    }
+}
+
+private struct AdjustPill: View {
+    var body: some View {
+        // 동작 보류 (시각 전용) — 추후 조정 화면 연동
+        HStack(spacing: 4) {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 11, weight: .semibold))
+            Text("조정")
+                .font(.system(size: 14, weight: .medium))
+        }
+        .foregroundStyle(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(Color.fillTertiary, in: Capsule())
+    }
+}
+
+/// 비상호작용 슬라이더 (추천값 표시 전용)
+private struct EnvSlider: View {
+    let fraction: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let f = min(max(fraction, 0), 1)
+
+            ZStack {
+                // 눈금 5개 (트랙 아래)
+                HStack(spacing: 0) {
+                    ForEach(0..<5, id: \.self) { index in
+                        Circle()
+                            .fill(Color.white.opacity(0.2))
+                            .frame(width: 4, height: 4)
+                        if index < 4 { Spacer(minLength: 0) }
+                    }
+                }
+                .offset(y: 9)
+
+                // 트랙
+                Capsule()
+                    .fill(Color.fillPrimary)
+                    .frame(height: 6)
+
+                // 채움 (값 비율)
+                HStack(spacing: 0) {
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: w * f, height: 6)
+                    Spacer(minLength: 0)
+                }
+
+                // 노브
+                Capsule()
+                    .fill(.white)
+                    .frame(width: 30, height: 28)
+                    .shadow(color: .black.opacity(0.2), radius: 5, y: 3)
+                    .position(x: min(max(w * f, 15), w - 15), y: geo.size.height / 2)
+            }
+        }
+        .frame(height: 50)
+    }
+}
+
+// MARK: - Colors (Figma 다크 토큰)
+
+private extension Color {
+    static let fillTertiary = Color(red: 118 / 255, green: 118 / 255, blue: 128 / 255).opacity(0.24)
+    static let fillPrimary = Color(red: 120 / 255, green: 120 / 255, blue: 128 / 255).opacity(0.36)
+
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
         )
     }
 }
 
-// MARK: - Color Wheel Sheet
+// MARK: - Preview
 
-struct ColorWheelSheet: View {
-    let viewModel: ReadingViewModel
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        VStack(spacing: 24) {
-            // 헤더 (제목 + 적용 버튼)
-            HStack {
-                Text("색상 선택")
-                    .font(.headline)
-                Spacer()
-                Button("적용") {
-                    viewModel.commitLighting()
-                    dismiss()
-                }
-                .fontWeight(.semibold)
-            }
+#Preview("컨트롤 카드") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        ControlCard(lightingColor: Color(hue: 0.11, saturation: 0.85, brightness: 1.0), brightness: 50)
             .padding(.horizontal, 20)
-            .padding(.top, 20)
-
-            // 원형 색상환
-            CircularColorWheel(
-                hue: Double(viewModel.lightingConfig?.hue ?? 0),
-                saturation: Double(viewModel.lightingConfig?.saturation ?? 0),
-                onChange: { newHue, newSat in
-                    viewModel.updateLighting(hue: newHue, saturation: newSat)
-                }
-            )
-            .frame(width: 320, height: 320)
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
-        .background(Color(UIColor.systemBackground))
     }
-}
-
-// MARK: - Circular Color Wheel
-
-struct CircularColorWheel: View {
-    let hue: Double         // 0-360
-    let saturation: Double  // 0-100
-    let onChange: (Int, Int) -> Void
-
-    var body: some View {
-        GeometryReader { geometry in
-            let size = min(geometry.size.width, geometry.size.height)
-            let radius = size / 2
-
-            ZStack {
-                // 1. 색상환 (각도별 Hue)
-                Circle()
-                    .fill(
-                        AngularGradient(
-                            gradient: Gradient(colors: [
-                                .red, .yellow, .green, .cyan, .blue, .purple, .red
-                            ]),
-                            center: .center,
-                            startAngle: .degrees(0),
-                            endAngle: .degrees(360)
-                        )
-                    )
-
-                // 2. 채도 그라디언트 (중심은 흰색)
-                Circle()
-                    .fill(
-                        RadialGradient(
-                            gradient: Gradient(colors: [.white, .white.opacity(0)]),
-                            center: .center,
-                            startRadius: 0,
-                            endRadius: radius
-                        )
-                    )
-
-                // 3. 현재 위치 표시 인디케이터
-                let angleRad = hue * .pi / 180.0
-                let distance = (saturation / 100.0) * radius
-                let indicatorX = radius + CGFloat(distance * cos(angleRad))
-                let indicatorY = radius + CGFloat(distance * sin(angleRad))
-
-                Circle()
-                    .strokeBorder(.white, lineWidth: 3)
-                    .background(Circle().fill(.clear))
-                    .frame(width: 22, height: 22)
-                    .shadow(color: .black.opacity(0.3), radius: 2)
-                    .position(x: indicatorX, y: indicatorY)
-            }
-            .frame(width: size, height: size)
-            .contentShape(Circle())
-            .gesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { value in
-                        let dx = value.location.x - radius
-                        let dy = value.location.y - radius
-                        let dist = sqrt(dx * dx + dy * dy)
-
-                        // 반지름 밖 터치는 원 가장자리로 클램프
-                        let clampedDist = min(dist, radius)
-
-                        // 각도 계산 (0도 = 오른쪽, 시계방향)
-                        var angle = atan2(dy, dx) * 180 / .pi
-                        if angle < 0 { angle += 360 }
-
-                        let hueDeg = Int(angle) % 360
-                        let satPercent = Int((clampedDist / radius) * 100)
-
-                        onChange(hueDeg, satPercent)
-                    }
-            )
-        }
-    }
+    .preferredColorScheme(.dark)
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -187,7 +187,6 @@ struct ReadingView: View {
         ) {
             showStopAlert = true
         }
-        .environment(\.colorScheme, .dark)
     }
 
     // MARK: - Helpers

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -261,7 +261,7 @@ private struct ControlCard: View {
     var body: some View {
         VStack(spacing: 16) {
             EnvControlRow(
-                systemImage: "lightbulb.fill",
+                symbol: .lightbulb,
                 title: "조명",
                 valueLabel: "밝기",
                 value: brightnessBinding,
@@ -282,7 +282,7 @@ private struct ControlCard: View {
                 .padding(.horizontal, 8)
 
             EnvControlRow(
-                systemImage: "speaker.wave.2.fill",
+                symbol: .speaker,
                 title: "음악",
                 valueLabel: "볼륨",
                 value: volumeBinding,
@@ -299,7 +299,7 @@ private struct ControlCard: View {
                     )
                     .frame(width: 56, height: 56)
                     .overlay {
-                        Image(systemName: "waveform")
+                        Image(.waveform)
                             .font(.system(size: 20, weight: .semibold))
                             .foregroundStyle(.white)
                     }
@@ -312,7 +312,7 @@ private struct ControlCard: View {
 }
 
 private struct EnvControlRow<Leading: View>: View {
-    let systemImage: String
+    let symbol: SymbolLiterals
     let title: String
     let valueLabel: String
     @Binding var value: Double
@@ -331,7 +331,7 @@ private struct EnvControlRow<Leading: View>: View {
         VStack(spacing: 16) {
             HStack {
                 HStack(spacing: 6) {
-                    Image(systemName: systemImage)
+                    Image(symbol)
                         .font(.system(size: 15, weight: .semibold))
                     Text(title)
                         .font(.body2Medium)
@@ -368,7 +368,7 @@ private struct AdjustPill: View {
     var body: some View {
         // 동작 보류 (시각 전용) — 추후 조정 화면 연동
         HStack(spacing: 4) {
-            Image(systemName: "slider.horizontal.3")
+            Image(.sliderHorizontal)
                 .font(.system(size: 11, weight: .semibold))
             Text("조정")
                 .font(.labelMedium)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -140,7 +140,7 @@ struct ReadingView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(height: 60)
-                .foregroundStyle(Color(hex: 0xEBEBF5).opacity(0.3)) // Figma: Labels/Tertiary
+                .foregroundStyle(Color(.tertiaryLabel)) // Labels/Tertiary (iOS 시스템색)
 
             VStack(spacing: 12) {
                 Text(StringLiterals.Reading.settingTitle)
@@ -162,7 +162,7 @@ struct ReadingView: View {
                 .frame(height: 72)
                 .foregroundStyle(
                     LinearGradient(
-                        colors: [Color(hex: 0x92CFB1), Color(hex: 0xBFEE68), Color(hex: 0xFFCB24)],
+                        colors: [Color(hex: 0x92CFB1), .green0, .yellow20],
                         startPoint: .top,
                         endPoint: .bottom
                     )
@@ -237,7 +237,7 @@ private struct ControlCard: View {
 
     /// 채움 색(그라데이션). 네이티브 Slider tint로 넘기면 단색으로 뭉개질 수 있음(의도).
     private static let fill = LinearGradient(
-        colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+        colors: [.yellow20, .green0],
         startPoint: .leading,
         endPoint: .trailing
     )

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -33,7 +33,7 @@ struct ReadingView: View {
             if isFinishing {
                 CheckmarkTransitionView {
                     coordinator.showStopReading(
-                        bookTitle: viewModel.book.bookTitle,
+                        book: viewModel.book,
                         conversations: viewModel.conversations
                     )
                 }
@@ -411,11 +411,27 @@ private extension Color {
 
 // MARK: - Preview
 
-#Preview("컨트롤 카드") {
-    ZStack {
-        Color.black.ignoresSafeArea()
-        ControlCard(lightingColor: Color(hue: 0.11, saturation: 0.85, brightness: 1.0), brightness: 50)
-            .padding(.horizontal, 20)
+#if DEBUG
+#Preview("세팅 중") {
+    NavigationStack {
+        ReadingView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            viewModel: ReadingViewModel(previewBook: .mockISBN, state: .setting)
+        )
     }
-    .preferredColorScheme(.dark)
 }
+
+#Preview("독서 중") {
+    NavigationStack {
+        ReadingView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            viewModel: ReadingViewModel(
+                previewBook: .mockISBN,
+                state: .reading,
+                lightingConfig: LightingConfig(hue: 40, saturation: 80, brightness: 70),
+                musicCategory: .forest
+            )
+        )
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -100,12 +100,16 @@ struct ReadingView: View {
 
     /// 세팅 중 (·error): 중앙 아이콘 + 문구 + '환경 세팅 중지'
     private var settingLayout: some View {
-        VStack {
-            Spacer()
+        ZStack {
+            // Figma: 콘텐츠 블록 = 화면 세로 중심 -30pt
             settingStatus
-            Spacer()
-            actionButton
-                .padding(.horizontal, 20)
+                .offset(y: -30)
+
+            VStack {
+                Spacer()
+                actionButton
+                    .padding(.horizontal, 20)
+            }
         }
     }
 
@@ -138,10 +142,10 @@ struct ReadingView: View {
             Image(.home)
                 .resizable()
                 .scaledToFit()
-                .frame(height: 79)
-                .foregroundStyle(.white.opacity(0.22))
+                .frame(height: 60)
+                .foregroundStyle(Color(hex: 0xEBEBF5).opacity(0.3)) // Figma: Labels/Tertiary
 
-            VStack(spacing: 6) {
+            VStack(spacing: 12) {
                 Text(StringLiterals.Reading.settingTitle)
                     .font(.body1Regular)
                     .foregroundStyle(.white)
@@ -202,23 +206,27 @@ struct ReadingView: View {
 
     private var pulseBackground: some View {
         ZStack {
-            Color.black
-            Circle()
-                .fill(
-                    RadialGradient(
-                        colors: viewModel.state == .setting
-                            ? [.yellow0, .yellow20, .clear]
-                            : [lightingColor, lightingColor.opacity(0.4), .clear],
-                        center: .center,
-                        startRadius: 0,
-                        endRadius: 305
+            // Figma: 세팅 화면 base = Backgrounds/Secondary, 독서 중은 몰입용 검정
+            (viewModel.state == .setting ? Color.backgroundSecondary : Color.black)
+
+            if viewModel.state == .setting {
+                // Figma: 흰색 타원 글로우(610×610, 중앙), opacity 0↔100 왕복
+                Circle()
+                    .fill(
+                        EllipticalGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.2), location: 0),
+                                .init(color: .white.opacity(0), location: 1)
+                            ],
+                            center: .center
+                        )
                     )
-                )
-                .frame(width: 610, height: 610)
-                .scaleEffect(isPulsing ? 1.0 : 0.85)
-                .opacity(isPulsing ? 0.4 : 0.1)
-                .blur(radius: 50)
-                .animation(.easeInOut(duration: 1.5), value: viewModel.state)
+                    .frame(width: 610, height: 610)
+                    .opacity(isPulsing ? 1.0 : 0.0)
+                    .animation(.easeInOut(duration: 1.5), value: viewModel.state)
+            } else {
+                EmptyView()
+            }
         }
         .ignoresSafeArea()
     }
@@ -274,7 +282,7 @@ private struct ControlCard: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
-        .background(Color(hex: 0x1C1C1E), in: RoundedRectangle(cornerRadius: 24))
+        .background(Color.backgroundSecondary, in: RoundedRectangle(cornerRadius: 24))
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -122,11 +122,8 @@ struct ReadingView: View {
 
             Spacer().frame(height: 52)
 
-            ControlCard(
-                lightingColor: lightingColor,
-                brightness: viewModel.lightingConfig?.brightness ?? 50
-            )
-            .padding(.horizontal, 20)
+            ControlCard(viewModel: viewModel, lightingColor: lightingColor)
+                .padding(.horizontal, 20)
 
             Spacer()
 
@@ -235,8 +232,31 @@ struct ReadingView: View {
 // MARK: - Control Card (조명 / 음악)
 
 private struct ControlCard: View {
+    let viewModel: ReadingViewModel
     let lightingColor: Color
-    let brightness: Int
+
+    /// 채움 색(그라데이션). 네이티브 Slider tint로 넘기면 단색으로 뭉개질 수 있음(의도).
+    private static let fill = LinearGradient(
+        colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+        startPoint: .leading,
+        endPoint: .trailing
+    )
+
+    /// 밝기: 드래그 중 쓰로틀 전송(updateLighting), 손 뗌 시 즉시(commitLighting)
+    private var brightnessBinding: Binding<Double> {
+        Binding(
+            get: { Double(viewModel.lightingConfig?.brightness ?? 50) },
+            set: { viewModel.updateLighting(brightness: Int($0.rounded())) }
+        )
+    }
+
+    /// 볼륨: 0~1 → audioPlayerService 즉시 반영
+    private var volumeBinding: Binding<Double> {
+        Binding(
+            get: { Double(viewModel.volume) },
+            set: { viewModel.setVolume(Float($0)) }
+        )
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -244,8 +264,12 @@ private struct ControlCard: View {
                 systemImage: "lightbulb.fill",
                 title: "조명",
                 valueLabel: "밝기",
-                percentText: "\(brightness)%",
-                fraction: Double(brightness) / 100.0
+                value: brightnessBinding,
+                range: 0...100,
+                fill: Self.fill,
+                onEditingChanged: { editing in
+                    if !editing { viewModel.commitLighting() }
+                }
             ) {
                 Circle()
                     .fill(lightingColor)
@@ -261,8 +285,9 @@ private struct ControlCard: View {
                 systemImage: "speaker.wave.2.fill",
                 title: "음악",
                 valueLabel: "볼륨",
-                percentText: "50%",          // 추천 볼륨 데이터 없음 → 고정 더미
-                fraction: 0.5
+                value: volumeBinding,
+                range: 0...1,
+                fill: Self.fill
             ) {
                 RoundedRectangle(cornerRadius: 12)
                     .fill(
@@ -290,9 +315,17 @@ private struct EnvControlRow<Leading: View>: View {
     let systemImage: String
     let title: String
     let valueLabel: String
-    let percentText: String
-    let fraction: Double
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let fill: LinearGradient
+    var onEditingChanged: (Bool) -> Void = { _ in }
     @ViewBuilder let leading: () -> Leading
+
+    private var percent: Int {
+        let span = range.upperBound - range.lowerBound
+        guard span > 0 else { return 0 }
+        return Int((((value - range.lowerBound) / span) * 100).rounded())
+    }
 
     var body: some View {
         VStack(spacing: 16) {
@@ -319,12 +352,12 @@ private struct EnvControlRow<Leading: View>: View {
                             .font(.labelRegular)
                             .foregroundStyle(.white.opacity(0.7))
                         Spacer()
-                        Text(percentText)
+                        Text("\(percent)%")
                             .font(.labelMedium)
                             .foregroundStyle(.white)
                     }
 
-                    EnvSlider(fraction: fraction)
+                    TickSlider(value: $value, in: range, fill: fill, onEditingChanged: onEditingChanged)
                 }
             }
         }
@@ -347,55 +380,48 @@ private struct AdjustPill: View {
     }
 }
 
-/// 비상호작용 슬라이더 (추천값 표시 전용)
-private struct EnvSlider: View {
-    let fraction: Double
+/// 네이티브 Slider — iOS 26 `ticks:` 로 틱 기본 제공. (수제 오버레이 불필요)
+/// tint에 그라데이션을 주지만 UISlider 브리지 특성상 단색으로 뭉개질 수 있음(의도).
+private struct TickSlider: View {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let fill: LinearGradient
+    var onEditingChanged: (Bool) -> Void
+
+    init(
+        value: Binding<Double>,
+        in range: ClosedRange<Double>,
+        fill: LinearGradient,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in }
+    ) {
+        self._value = value
+        self.range = range
+        self.fill = fill
+        self.onEditingChanged = onEditingChanged
+    }
+
+    /// 범위 양끝 포함 5개 틱 위치
+    private var tickValues: [Double] {
+        let lo = range.lowerBound
+        let hi = range.upperBound
+        return (0..<5).map { lo + (hi - lo) * Double($0) / 4 }
+    }
 
     var body: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let f = min(max(fraction, 0), 1)
-
-            ZStack {
-                // 눈금 5개 (트랙 아래)
-                HStack(spacing: 0) {
-                    ForEach(0..<5, id: \.self) { index in
-                        Circle()
-                            .fill(Color.white.opacity(0.2))
-                            .frame(width: 4, height: 4)
-                        if index < 4 { Spacer(minLength: 0) }
-                    }
-                }
-                .offset(y: 9)
-
-                // 트랙
-                Capsule()
-                    .fill(Color.fillPrimary)
-                    .frame(height: 6)
-
-                // 채움 (값 비율)
-                HStack(spacing: 0) {
-                    Capsule()
-                        .fill(
-                            LinearGradient(
-                                colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                        )
-                        .frame(width: w * f, height: 6)
-                    Spacer(minLength: 0)
-                }
-
-                // 노브
-                Capsule()
-                    .fill(.white)
-                    .frame(width: 30, height: 28)
-                    .shadow(color: .black.opacity(0.2), radius: 5, y: 3)
-                    .position(x: min(max(w * f, 15), w - 15), y: geo.size.height / 2)
-            }
-        }
-        .frame(height: 50)
+        Slider(
+            value: $value,
+            in: range,
+            label: { EmptyView() },
+            ticks: {
+                SliderTick(tickValues[0])
+                SliderTick(tickValues[1])
+                SliderTick(tickValues[2])
+                SliderTick(tickValues[3])
+                SliderTick(tickValues[4])
+            },
+            onEditingChanged: onEditingChanged
+        )
+        .tint(fill)
     }
 }
 
@@ -403,7 +429,6 @@ private struct EnvSlider: View {
 
 private extension Color {
     static let fillTertiary = Color(red: 118 / 255, green: 118 / 255, blue: 128 / 255).opacity(0.24)
-    static let fillPrimary = Color(red: 120 / 255, green: 120 / 255, blue: 128 / 255).opacity(0.36)
 
     init(hex: UInt) {
         self.init(

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -84,10 +84,10 @@ struct ReadingView: View {
                 set: { _ in }
             )
         ) {
-            Button("재시도", role: .cancel) {
+            Button(StringLiterals.Reading.retry, role: .cancel) {
                 Task { await viewModel.retry() }
             }
-            Button("닫기", role: .destructive) {
+            Button(StringLiterals.Reading.close, role: .destructive) {
                 coordinator.pop()
             }
         }
@@ -262,8 +262,8 @@ private struct ControlCard: View {
         VStack(spacing: 16) {
             EnvControlRow(
                 symbol: .lightbulb,
-                title: "조명",
-                valueLabel: "밝기",
+                title: StringLiterals.Reading.lightingTitle,
+                valueLabel: StringLiterals.Reading.brightness,
                 value: brightnessBinding,
                 range: 0...100,
                 fill: Self.fill,
@@ -283,8 +283,8 @@ private struct ControlCard: View {
 
             EnvControlRow(
                 symbol: .speaker,
-                title: "음악",
-                valueLabel: "볼륨",
+                title: StringLiterals.Reading.musicTitle,
+                valueLabel: StringLiterals.Reading.volume,
                 value: volumeBinding,
                 range: 0...1,
                 fill: Self.fill
@@ -370,7 +370,7 @@ private struct AdjustPill: View {
         HStack(spacing: 4) {
             Image(.sliderHorizontal)
                 .font(.system(size: 11, weight: .semibold))
-            Text("조정")
+            Text(StringLiterals.Reading.adjust)
                 .font(.labelMedium)
         }
         .foregroundStyle(.white)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -79,6 +79,24 @@ final class ReadingViewModel {
         audioPlayerService.resume()
     }
 
+#if DEBUG
+    /// SwiftUI 프리뷰 전용 — 원하는 상태/추천값으로 즉시 구성 (네트워크 호출 없음)
+    convenience init(
+        previewBook: BookProfileModel,
+        state: ReadingState,
+        lightingConfig: LightingConfig? = nil,
+        musicCategory: MusicCategory? = nil,
+        conversations: [ConversationProfile] = []
+    ) {
+        self.init(book: previewBook, lightingController: MockLightingController())
+        self.state = state
+        self.lightingConfig = lightingConfig
+        self.musicCategory = musicCategory
+        self.conversations = conversations
+        self.hasStarted = true // startSetup() 조기 종료 → Gemini 호출 차단
+    }
+#endif
+
     // MARK: - Public
 
     func startSetup() async {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -28,7 +28,7 @@ struct ResultView: View {
             VStack(spacing: 0) {
                 header
 
-                Spacer().frame(height: 48)
+                Spacer()
 
                 flameRow
 
@@ -36,7 +36,7 @@ struct ResultView: View {
 
                 BookStackAnimationView()
 
-                Spacer().frame(height: 16)
+                Spacer().frame(height: 30)
 
                 Text(StringLiterals.Reading.todayReadBooks(todaySessions.count))
                     .font(.system(size: 24, weight: .medium))

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -37,7 +37,7 @@ struct ResultView: View {
                 Spacer().frame(height: 30)
 
                 Text(StringLiterals.Reading.todayReadBooks(todaySessions.count))
-                    .font(.system(size: 24, weight: .medium))
+                    .font(.headlineMedium)
                     .foregroundStyle(.white)
                     .multilineTextAlignment(.center)
                     .lineSpacing(6)
@@ -98,7 +98,7 @@ struct ResultView: View {
                     )
                 )
             Text("\(flameCount)")
-                .font(.system(size: 20, weight: .semibold))
+                .font(.body1SemiBold)
                 .foregroundStyle(.white)
         }
     }
@@ -137,7 +137,7 @@ private struct ResultBookThumbnail: View {
                 .clipShape(RoundedRectangle(cornerRadius: 4))
 
             Text(title)
-                .font(.system(size: 14, weight: .medium))
+                .font(.labelMedium)
                 .foregroundStyle(.white)
                 .lineLimit(1)
                 .truncationMode(.tail)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -153,24 +153,12 @@ private struct ResultBookThumbnail: View {
                 case .success(let image):
                     image.resizable().scaledToFill()
                 default:
-                    Color(hex: 0x2C2C2E)
+                    Color(.tertiarySystemBackground)
                 }
             }
         } else {
-            Color(hex: 0x2C2C2E)
+            Color(.tertiarySystemBackground)
         }
-    }
-}
-
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -26,8 +26,6 @@ struct ResultView: View {
             Color.black.ignoresSafeArea()
 
             VStack(spacing: 0) {
-                header
-
                 Spacer()
 
                 flameRow
@@ -61,34 +59,29 @@ struct ResultView: View {
             .ignoresSafeArea(.container, edges: .bottom)
         }
         .preferredColorScheme(.dark)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden(true)
-        .toolbar(.hidden, for: .navigationBar)
-    }
-
-    // MARK: - Subviews
-
-    private var header: some View {
-        ZStack {
-            Text(StringLiterals.Reading.resultTitle)
-                .font(.headlineRegular)
-                .foregroundStyle(.white)
-
-            HStack {
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
                 Button {
                     coordinator.pop()
                 } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(.white)
-                        .frame(width: 44, height: 44)
-                        .glassEffect(.regular, in: Circle())
                 }
-                Spacer()
+            }
+            // 제목 색을 시스템 네비바(앱 라이트 고정→검정)에 맡기지 않고 흰색 콘텐츠로 직접 렌더
+            ToolbarItem(placement: .principal) {
+                Text(StringLiterals.Reading.resultTitle)
+                    .font(.headline)
+                    .foregroundStyle(.white)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
     }
+
+    // MARK: - Subviews
 
     private var flameRow: some View {
         HStack(spacing: 4) {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -4,6 +4,8 @@
 //
 //  Created by 문창재 on 2/12/26.
 //
+//  책 읽기 종료 → 결과창 (디자인 2635 / 2669)
+//
 
 import SwiftUI
 
@@ -12,50 +14,197 @@ struct ResultView: View {
     let coordinator: AppCoordinator
     let repository: ReadingSessionRepositoryProtocol
 
+    // TODO: 연속일(streak) 데이터 연동 — 현재 더미 고정값
+    private let flameCount = 12
+
+    private var todaySessions: [ReadingSessionProfile] {
+        (try? repository.fetchTodaySessions()) ?? []
+    }
+
     var body: some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 0) {
-                Text(StringLiterals.Reading.todayBookCount((try? repository.fetchTodaySessions().count) ?? 0))
-                    .font(.title2Medium)
-                    .padding(.top, 18)
-                    .padding(.horizontal, 20)
+        ZStack {
+            Color.black.ignoresSafeArea()
 
-                ReadingLogCalendar(readDates: (try? repository.fetchReadDates()) ?? [], showNavigation: false)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 20)
-                    
+            VStack(spacing: 0) {
+                header
 
-                StatCard(
-                    icon: SymbolLiterals.calendar.rawValue,
-                    title: StringLiterals.My.monthlyBookCount,
-                    value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.readingUnit)",
-                    isWide: true
-                )
+                Spacer().frame(height: 48)
+
+                flameRow
+
+                Spacer().frame(height: 52)
+
+                BookStackAnimationView()
+
+                Spacer().frame(height: 16)
+
+                Text(StringLiterals.Reading.todayReadBooks(todaySessions.count))
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(6)
+                    .tracking(0.5)
+
+                Spacer().frame(height: 52)
+
+                bookThumbnails
+
+                Spacer()
+
+                PrimaryButtonSwiftUI(title: StringLiterals.Reading.homeButton) {
+                    coordinator.popToHome()
+                }
                 .padding(.horizontal, 20)
+                .padding(.bottom, 30)
             }
-            Spacer()
-
-            PrimaryButtonSwiftUI(title: StringLiterals.Reading.homeButton) {
-                coordinator.popToHome()
-            }
-            .padding(.horizontal, 20)
-            .padding(.bottom, 20)
+            // 하단 버튼을 물리 화면 바닥에서 30pt에 고정 (다른 화면과 통일)
+            .ignoresSafeArea(.container, edges: .bottom)
         }
-        .navigationTitle(StringLiterals.Reading.resultTitle)
-        .navigationBarTitleDisplayMode(.inline)
+        .preferredColorScheme(.dark)
         .navigationBarBackButtonHidden(true)
-        .background(
-            RadialGradient(
-                colors: [
-                    Color(red: 1, green: 0.77, blue: 0.016).opacity(0.2),
-                    Color(red: 1, green: 0.77, blue: 0.016).opacity(0)
-                ],
-                center: .center,
-                startRadius: 0,
-                endRadius: 305
-            )
-            .frame(width: 589, height: 610)
-            .offset(y: 150)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        ZStack {
+            Text(StringLiterals.Reading.resultTitle)
+                .font(.headlineRegular)
+                .foregroundStyle(.white)
+
+            HStack {
+                Button {
+                    coordinator.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(.white)
+                        .frame(width: 44, height: 44)
+                        .glassEffect(.regular, in: Circle())
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private var flameRow: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "flame.fill")
+                .font(.system(size: 18))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [
+                            BookStackAnimationView.gradientColors[0], // 노랑
+                            BookStackAnimationView.gradientColors[1]   // 연두
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+            Text("\(flameCount)")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
+
+    @ViewBuilder
+    private var bookThumbnails: some View {
+        let books = todaySessions.map(\.bookProfile)
+        if !books.isEmpty {
+            // 적으면 가운데 정렬, 많으면(6권 등) 가로 스크롤
+            GeometryReader { geo in
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: 16) {
+                        ForEach(Array(books.enumerated()), id: \.offset) { _, book in
+                            ResultBookThumbnail(coverURL: book.bookCoverImageURL, title: book.bookTitle)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .frame(minWidth: geo.size.width, alignment: .center)
+                }
+            }
+            .frame(height: 124)
+        }
+    }
+}
+
+// MARK: - Book Thumbnail
+
+private struct ResultBookThumbnail: View {
+    let coverURL: URL?
+    let title: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            cover
+                .frame(width: 72, height: 96)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            Text(title)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 72, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var cover: some View {
+        if let coverURL {
+            AsyncImage(url: coverURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    Color(hex: 0x2C2C2E)
+                }
+            }
+        } else {
+            Color(hex: 0x2C2C2E)
+        }
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
         )
     }
 }
+
+// MARK: - Preview
+
+#if DEBUG
+private struct PreviewResultRepository: ReadingSessionRepositoryProtocol {
+    func saveSession(_ session: ReadingSessionProfile, bookISBN: String) throws {}
+    func fetchAllSessions() throws -> [ReadingSessionProfile] { ReadingSessionProfile.mockList }
+    func findSession(by id: UUID) throws -> ReadingSessionProfile? { nil }
+    func deleteSession(by id: UUID) throws {}
+    func fetchTodaySessions() throws -> [ReadingSessionProfile] {
+        // 가로 스크롤 확인용 6권
+        (0..<6).map { _ in ReadingSessionProfile.mock }
+    }
+    func fetchMonthlyBookCount() throws -> Int { 5 }
+    func fetchTotalBookCount() throws -> Int { 12 }
+    func fetchTotalSeconds() throws -> Int { 3600 }
+    func fetchReadDates() throws -> Set<DateComponents> { [] }
+}
+
+#Preview {
+    NavigationStack {
+        ResultView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            repository: PreviewResultRepository()
+        )
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -67,7 +67,7 @@ struct ResultView: View {
                 Button {
                     coordinator.pop()
                 } label: {
-                    Image(systemName: "chevron.left")
+                    Image(.back)
                         .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(.white)
                 }
@@ -85,7 +85,7 @@ struct ResultView: View {
 
     private var flameRow: some View {
         HStack(spacing: 4) {
-            Image(systemName: "flame.fill")
+            Image(.flame)
                 .font(.system(size: 18))
                 .foregroundStyle(
                     LinearGradient(

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -67,10 +67,7 @@ struct StopReadingView: View {
 
     private var talkButton: some View {
         Button {
-            coordinator.showConversation(
-                bookTitle: book.bookTitle,
-                conversations: conversations
-            )
+            coordinator.showConversation(conversations: conversations)
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "bubble.left.fill")

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -59,7 +59,8 @@ struct StopReadingView: View {
                     .foregroundStyle(.white)
                 Text(book.bookTitle)
                     .font(.system(size: 18))
-                    .foregroundStyle(Color(white: 0.92).opacity(0.7))
+                    // Labels/Secondary (iOS 시스템색)
+                    .foregroundStyle(Color(.secondaryLabel))
             }
             .multilineTextAlignment(.center)
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -4,83 +4,135 @@
 //
 //  Created by 문창재 on 2/8/26.
 //
+//  책 읽기 완료 화면 (디자인 2757)
+//
 
 import SwiftUI
 
 struct StopReadingView: View {
     let coordinator: AppCoordinator
-    let bookTitle: String
+    let book: BookProfileModel
     let conversations: [ConversationProfile]
 
     var body: some View {
-        VStack {
-            conversationSection
-            Spacer()
-            buttonSection
+        ZStack {
+            Color(hex: 0x1C1C1E)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer().frame(height: 40)
+
+                bookSection
+
+                Spacer().frame(height: 48)
+
+                talkButton
+
+                Spacer()
+
+                bottomButtons
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 30)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
         }
-        .navigationTitle(bookTitle)
-        .navigationBarTitleDisplayMode(.inline)
+        .preferredColorScheme(.dark)
+        // 네비바 공간은 유지(콘텐츠 위치 고정), 타이틀·뒤로가기·배경만 숨김
         .navigationBarBackButtonHidden(true)
-        .padding(.horizontal, 20)
-        .padding(.top, 12)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.visible, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
     }
 
     // MARK: - Subviews
 
-    private var conversationSection: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            VStack(alignment: .leading, spacing: 8) {
-                Image(.conversation)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 26)
-                Text(StringLiterals.Reading.conversationPrompt)
-                    .font(.title2Medium)
-            }
-            
-            ScrollView {
-                VStack(spacing: 16) {
-                    ForEach(conversations) { item in
-                        ConversationCard(
-                            question: item.question,
-                            effect: item.effect
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private var buttonSection: some View {
-        VStack(spacing: 14) {
-            PrimaryButtonSwiftUI(title: StringLiterals.Reading.restartScan, action: {
-                    coordinator.restartScanner()
-                })
-            WhiteButtonSwiftUI(title: StringLiterals.Reading.stopReadingButton, action: {
-                    coordinator.showResult()
-                })
-        }
-    }
-}
-
-// MARK: - Subviews
-
-private struct ConversationCard: View {
-    let question: String
-    let effect: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            CharWrappingText(text: question, font: .body2Medium, color: .gray10)
-            CharWrappingText(
-                text: effect,
-                font: .calloutRegular,
-                color: .gray40
+    private var bookSection: some View {
+        VStack(spacing: 24) {
+            BookCoverThumbnail(
+                coverURL: book.bookCoverImageURL,
+                readCount: 4 // TODO: 실제 읽어준 횟수 연동 (현재 더미)
             )
+
+            VStack(spacing: 12) {
+                Text(StringLiterals.Reading.readingDoneTitle)
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(.white)
+                Text(book.bookTitle)
+                    .font(.system(size: 18))
+                    .foregroundStyle(Color(white: 0.92).opacity(0.7))
+            }
+            .multilineTextAlignment(.center)
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.yellow0)
-        .clipShape(RoundedRectangle(cornerRadius: 18))
+    }
+
+    private var talkButton: some View {
+        Button {
+            coordinator.showConversation(
+                bookTitle: book.bookTitle,
+                conversations: conversations
+            )
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "bubble.left.fill")
+                    .font(.system(size: 13))
+                Text(StringLiterals.Reading.talkWithChild)
+                    .font(.system(size: 15, weight: .medium))
+            }
+            .foregroundStyle(Color(hex: 0xF5F5F5))
+            .padding(.horizontal, 20)
+            .frame(height: 48)
+            .glassEffect(.regular, in: Capsule())
+        }
+    }
+
+    private var bottomButtons: some View {
+        VStack(spacing: 14) {
+            // 다른 책 읽기 (보조 — 흐린 글래스)
+            Button {
+                coordinator.restartScanner()
+            } label: {
+                Capsule()
+                    .frame(height: 52)
+                    .foregroundStyle(.clear)
+                    .glassEffect()
+                    .overlay {
+                        Text(StringLiterals.Reading.readAnotherBook)
+                            .font(.buttonTitle)
+                            .foregroundStyle(Color(hex: 0xBFBFBF))
+                    }
+            }
+
+            // 책 읽기 종료 (주 — 글래스 다크)
+            PrimaryButtonSwiftUI(title: StringLiterals.Reading.finishReading) {
+                coordinator.showResult()
+            }
+            .environment(\.colorScheme, .dark)
+        }
     }
 }
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        StopReadingView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            book: .mockISBN,
+            conversations: []
+        )
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -103,7 +103,6 @@ struct StopReadingView: View {
             PrimaryButtonSwiftUI(title: StringLiterals.Reading.finishReading) {
                 coordinator.showResult()
             }
-            .environment(\.colorScheme, .dark)
         }
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -94,7 +94,7 @@ struct StopReadingView: View {
                     .glassEffect()
                     .overlay {
                         Text(StringLiterals.Reading.readAnotherBook)
-                            .font(.buttonTitle)
+                            .font(.system(size: 17, weight: .medium))
                             .foregroundStyle(Color(hex: 0xBFBFBF))
                     }
             }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -71,7 +71,7 @@ struct StopReadingView: View {
             coordinator.showConversation(conversations: conversations)
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: "ellipsis.message.fill")
+                Image(.conversation)
                     .font(.system(size: 13))
                 Text(StringLiterals.Reading.talkWithChild)
                     .font(.buttonSmallMedium)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -16,7 +16,7 @@ struct StopReadingView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E)
+            Color.backgroundSecondary
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
@@ -70,7 +70,7 @@ struct StopReadingView: View {
             coordinator.showConversation(conversations: conversations)
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: "bubble.left.fill")
+                Image(systemName: "ellipsis.message.fill")
                     .font(.system(size: 13))
                 Text(StringLiterals.Reading.talkWithChild)
                     .font(.system(size: 15, weight: .medium))

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -55,10 +55,10 @@ struct StopReadingView: View {
 
             VStack(spacing: 12) {
                 Text(StringLiterals.Reading.readingDoneTitle)
-                    .font(.system(size: 24, weight: .medium))
+                    .font(.headlineMedium)
                     .foregroundStyle(.white)
                 Text(book.bookTitle)
-                    .font(.system(size: 18))
+                    .font(.body2Regular)
                     // Labels/Secondary (iOS 시스템색)
                     .foregroundStyle(Color(.secondaryLabel))
             }
@@ -74,7 +74,7 @@ struct StopReadingView: View {
                 Image(systemName: "ellipsis.message.fill")
                     .font(.system(size: 13))
                 Text(StringLiterals.Reading.talkWithChild)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.buttonSmallMedium)
             }
             .foregroundStyle(Color(hex: 0xF5F5F5))
             .padding(.horizontal, 20)
@@ -95,7 +95,7 @@ struct StopReadingView: View {
                     .glassEffect()
                     .overlay {
                         Text(StringLiterals.Reading.readAnotherBook)
-                            .font(.system(size: 17, weight: .medium))
+                            .font(.buttonMedium)
                             .foregroundStyle(Color(hex: 0xBFBFBF))
                     }
             }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -28,7 +28,8 @@ struct ChildAgeSettingView: View {
                     HStack(alignment: .firstTextBaseline, spacing: 12) {
                         Text("만")
                             .font(.system(size: 22))
-                            .foregroundStyle(Color(white: 0.92).opacity(0.7))
+                            // Labels/Secondary (iOS 시스템색)
+                            .foregroundStyle(Color(.secondaryLabel))
                         HStack(alignment: .firstTextBaseline, spacing: 4) {
                             Text("\(age)")
                                 .font(.system(size: 66, weight: .semibold))
@@ -85,7 +86,7 @@ private struct AgeSlider: View {
                     Capsule()
                         .fill(
                             LinearGradient(
-                                colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                                colors: [.yellow20, .green0],
                                 startPoint: .leading,
                                 endPoint: .trailing
                             )
@@ -126,20 +127,9 @@ private struct AgeSlider: View {
                 Text("\(maxAge)세")
             }
             .font(.system(size: 14))
-            .foregroundStyle(Color(white: 0.92).opacity(0.3))
+            // Labels/Tertiary (iOS 시스템색)
+            .foregroundStyle(Color(.tertiaryLabel))
         }
-    }
-}
-
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -27,15 +27,15 @@ struct ChildAgeSettingView: View {
                 VStack(spacing: 36) {
                     HStack(alignment: .firstTextBaseline, spacing: 12) {
                         Text("만")
-                            .font(.system(size: 22))
+                            .font(.display3Regular)
                             // Labels/Secondary (iOS 시스템색)
                             .foregroundStyle(Color(.secondaryLabel))
                         HStack(alignment: .firstTextBaseline, spacing: 4) {
                             Text("\(age)")
-                                .font(.system(size: 66, weight: .semibold))
+                                .font(.display1SemiBold)
                                 .foregroundStyle(.white)
                             Text("세")
-                                .font(.system(size: 28, weight: .semibold))
+                                .font(.display2SemiBold)
                                 .foregroundStyle(.white)
                         }
                     }
@@ -126,7 +126,7 @@ private struct AgeSlider: View {
                 Spacer()
                 Text("\(maxAge)세")
             }
-            .font(.system(size: 14))
+            .font(.labelRegular)
             // Labels/Tertiary (iOS 시스템색)
             .foregroundStyle(Color(.tertiaryLabel))
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -18,7 +18,7 @@ struct ChildAgeSettingView: View {
 
             VStack(spacing: 0) {
                 SettingIntro(
-                    systemImage: "figure.and.child.holdinghands",
+                    symbol: .childHands,
                     headline: StringLiterals.Setting.childAgeHeadline,
                     subtitle: StringLiterals.Setting.childAgeSubtitle
                 )

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -14,7 +14,7 @@ struct ChildAgeSettingView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E).ignoresSafeArea()
+            Color.backgroundSecondary.ignoresSafeArea()
 
             VStack(spacing: 0) {
                 SettingIntro(

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -26,7 +26,7 @@ struct ChildAgeSettingView: View {
 
                 VStack(spacing: 36) {
                     HStack(alignment: .firstTextBaseline, spacing: 12) {
-                        Text("만")
+                        Text(StringLiterals.Setting.agePrefix)
                             .font(.display3Regular)
                             // Labels/Secondary (iOS 시스템색)
                             .foregroundStyle(Color(.secondaryLabel))
@@ -34,7 +34,7 @@ struct ChildAgeSettingView: View {
                             Text("\(age)")
                                 .font(.display1SemiBold)
                                 .foregroundStyle(.white)
-                            Text("세")
+                            Text(StringLiterals.Setting.ageUnit)
                                 .font(.display2SemiBold)
                                 .foregroundStyle(.white)
                         }
@@ -122,9 +122,9 @@ private struct AgeSlider: View {
             .frame(height: 50)
 
             HStack {
-                Text("0세")
+                Text("0\(StringLiterals.Setting.ageUnit)")
                 Spacer()
-                Text("\(maxAge)세")
+                Text("\(maxAge)\(StringLiterals.Setting.ageUnit)")
             }
             .font(.labelRegular)
             // Labels/Tertiary (iOS 시스템색)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -1,0 +1,152 @@
+//
+//  ChildAgeSettingView.swift
+//  LivingStory-iOS
+//
+//  아이 나이 설정 (디자인 897-4862) — 현재 UI만, 값 더미
+//
+
+import SwiftUI
+
+struct ChildAgeSettingView: View {
+    let coordinator: AppCoordinator
+
+    @State private var age: Int = 13 // 더미 기본값
+
+    var body: some View {
+        ZStack {
+            Color(hex: 0x1C1C1E).ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                SettingIntro(
+                    systemImage: "figure.and.child.holdinghands",
+                    headline: StringLiterals.Setting.childAgeHeadline,
+                    subtitle: StringLiterals.Setting.childAgeSubtitle
+                )
+
+
+                VStack(spacing: 36) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text("만")
+                            .font(.system(size: 22))
+                            .foregroundStyle(Color(white: 0.92).opacity(0.7))
+                        HStack(alignment: .firstTextBaseline, spacing: 4) {
+                            Text("\(age)")
+                                .font(.system(size: 66, weight: .semibold))
+                                .foregroundStyle(.white)
+                            Text("세")
+                                .font(.system(size: 28, weight: .semibold))
+                                .foregroundStyle(.white)
+                        }
+                    }
+
+                    AgeSlider(age: $age)
+                }
+                .padding(.horizontal, 30)
+                .padding(.top, 120)
+
+                Spacer()
+
+                PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
+                    coordinator.pop()
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 30)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
+        }
+        .preferredColorScheme(.dark)
+        .navigationTitle(StringLiterals.Setting.childAgeTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+}
+
+// MARK: - Age Slider (0 ~ 13세)
+
+private struct AgeSlider: View {
+    @Binding var age: Int
+    private let maxAge = 13
+    private let knobWidth: CGFloat = 38
+    private let knobOverhang: CGFloat = 10 // 최댓값에서 트랙 끝에 살짝 걸치는 양
+
+    var body: some View {
+        VStack(spacing: 0) {
+            GeometryReader { geo in
+                let w = geo.size.width
+                let frac = CGFloat(age) / CGFloat(maxAge)
+
+                ZStack(alignment: .leading) {
+                    // 트랙
+                    Capsule()
+                        .fill(Color(red: 120/255, green: 120/255, blue: 128/255).opacity(0.36))
+                        .frame(height: 6)
+
+                    // 채움 (좌 노랑 → 우 연두)
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .frame(width: max(6, w * frac), height: 6)
+
+                    // 눈금 5개 — 트랙 아래
+                    HStack(spacing: 0) {
+                        ForEach(0..<5, id: \.self) { index in
+                            Circle().fill(Color.white.opacity(0.3)).frame(width: 4, height: 4)
+                            if index < 4 { Spacer(minLength: 0) }
+                        }
+                    }
+                    .offset(y: 12)
+
+                    // 노브
+                    Capsule()
+                        .fill(.white)
+                        .frame(width: knobWidth, height: 24)
+                        .shadow(color: .black.opacity(0.18), radius: 6, y: 4)
+                        .offset(x: -knobOverhang + (w - knobWidth + knobOverhang * 2) * frac)
+                }
+                .frame(height: 50)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            let x = min(max(0, value.location.x), w)
+                            age = Int((x / w * CGFloat(maxAge)).rounded())
+                        }
+                )
+            }
+            .frame(height: 50)
+
+            HStack {
+                Text("0세")
+                Spacer()
+                Text("\(maxAge)세")
+            }
+            .font(.system(size: 14))
+            .foregroundStyle(Color(white: 0.92).opacity(0.3))
+        }
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        ChildAgeSettingView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ChildAgeSettingView: View {
-    let coordinator: AppCoordinator
+    @Environment(\.dismiss) private var dismiss
 
     @State private var age: Int = 13 // 더미 기본값
 
@@ -47,7 +47,7 @@ struct ChildAgeSettingView: View {
                 Spacer()
 
                 PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
-                    coordinator.pop()
+                    dismiss()
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 30)
@@ -146,7 +146,7 @@ private extension Color {
 #if DEBUG
 #Preview {
     NavigationStack {
-        ChildAgeSettingView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+        ChildAgeSettingView()
     }
 }
 #endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -20,7 +20,7 @@ struct HomeSelectionView: View {
 
             VStack(spacing: 0) {
                 SettingIntro(
-                    systemImage: "house.fill",
+                    symbol: .home,
                     headline: StringLiterals.Setting.homeHeadline,
                     subtitle: StringLiterals.Setting.homeSubtitle
                 )
@@ -57,7 +57,7 @@ struct HomeSelectionView: View {
                             .foregroundStyle(.white)
                         Spacer()
                         if selectedIndex == index {
-                            Image(systemName: "checkmark")
+                            Image(.checkmark)
                                 .font(.system(size: 20, weight: .semibold))
                                 .foregroundStyle(.yellow60)
                         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -53,7 +53,7 @@ struct HomeSelectionView: View {
                 } label: {
                     HStack {
                         Text(name)
-                            .font(.system(size: 16))
+                            .font(.calloutRegular)
                             .foregroundStyle(.white)
                         Spacer()
                         if selectedIndex == index {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -16,7 +16,7 @@ struct HomeSelectionView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E).ignoresSafeArea()
+            Color.backgroundSecondary.ignoresSafeArea()
 
             VStack(spacing: 0) {
                 SettingIntro(

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HomeSelectionView: View {
-    let coordinator: AppCoordinator
+    @Environment(\.dismiss) private var dismiss
 
     // 더미 목록 / 선택
     private let homes = ["서울 집", "남양주 집"]
@@ -32,7 +32,7 @@ struct HomeSelectionView: View {
                 Spacer()
 
                 PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
-                    coordinator.pop()
+                    dismiss()
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 30)
@@ -95,7 +95,7 @@ private extension Color {
 #if DEBUG
 #Preview {
     NavigationStack {
-        HomeSelectionView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+        HomeSelectionView()
     }
 }
 #endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -59,7 +59,7 @@ struct HomeSelectionView: View {
                         if selectedIndex == index {
                             Image(systemName: "checkmark")
                                 .font(.system(size: 20, weight: .semibold))
-                                .foregroundStyle(Color(hex: 0xFCDF42))
+                                .foregroundStyle(.yellow60)
                         }
                     }
                     .padding(.leading, 20)
@@ -76,7 +76,8 @@ struct HomeSelectionView: View {
                 }
             }
         }
-        .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 26))
+        // Backgrounds/Tertiary (iOS 시스템색)
+        .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 26))
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -1,0 +1,101 @@
+//
+//  HomeSelectionView.swift
+//  LivingStory-iOS
+//
+//  집 선택 (디자인 897-4933) — 현재 UI만, 값 더미
+//
+
+import SwiftUI
+
+struct HomeSelectionView: View {
+    let coordinator: AppCoordinator
+
+    // 더미 목록 / 선택
+    private let homes = ["서울 집", "남양주 집"]
+    @State private var selectedIndex = 0
+
+    var body: some View {
+        ZStack {
+            Color(hex: 0x1C1C1E).ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                SettingIntro(
+                    systemImage: "house.fill",
+                    headline: StringLiterals.Setting.homeHeadline,
+                    subtitle: StringLiterals.Setting.homeSubtitle
+                )
+
+                homeList
+                    .padding(.horizontal, 20)
+                    .padding(.top, 53)
+
+                Spacer()
+
+                PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
+                    coordinator.pop()
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 30)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
+        }
+        .preferredColorScheme(.dark)
+        .navigationTitle(StringLiterals.Setting.homeTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+
+    private var homeList: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(homes.enumerated()), id: \.offset) { index, name in
+                Button {
+                    selectedIndex = index
+                } label: {
+                    HStack {
+                        Text(name)
+                            .font(.system(size: 16))
+                            .foregroundStyle(.white)
+                        Spacer()
+                        if selectedIndex == index {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 20, weight: .semibold))
+                                .foregroundStyle(Color(hex: 0xFCDF42))
+                        }
+                    }
+                    .padding(.leading, 20)
+                    .padding(.trailing, 12)
+                    .frame(height: 58)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                if index < homes.count - 1 {
+                    Divider()
+                        .overlay(Color(hex: 0x48484A))
+                        .padding(.horizontal, 20)
+                }
+            }
+        }
+        .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 26))
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        HomeSelectionView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -1,0 +1,90 @@
+//
+//  NotificationTimeSettingView.swift
+//  LivingStory-iOS
+//
+//  알림 시간 설정 (디자인 897-4898) — 현재 UI만, 값 더미
+//
+
+import SwiftUI
+
+struct NotificationTimeSettingView: View {
+    let coordinator: AppCoordinator
+
+    // 더미 기본값: 오후 09:30
+    @State private var time: Date = {
+        var comps = DateComponents()
+        comps.hour = 21
+        comps.minute = 30
+        return Calendar.current.date(from: comps) ?? Date()
+    }()
+    @State private var isOn = true
+
+    var body: some View {
+        ZStack {
+            Color(hex: 0x1C1C1E).ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                SettingIntro(
+                    systemImage: "alarm.fill",
+                    headline: StringLiterals.Setting.notificationHeadline,
+                    subtitle: StringLiterals.Setting.notificationSubtitle
+                )
+
+                DatePicker("", selection: $time, displayedComponents: .hourAndMinute)
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                    .tint(Color(hex: 0xFCDF42))
+                    .environment(\.locale, Locale(identifier: "en_US"))
+                    .padding(.top, 83)
+
+                HStack {
+                    Text(StringLiterals.Setting.notificationToggle)
+                        .font(.system(size: 16))
+                        .foregroundStyle(.white)
+                    Spacer()
+                    Toggle("", isOn: $isOn)
+                        .labelsHidden()
+                        .tint(Color(hex: 0xFFCB24))
+                }
+                .padding(.leading, 20)
+                .padding(.trailing, 12)
+                .frame(height: 58)
+                .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 26))
+                .padding(.horizontal, 20)
+                .padding(.top, 77)
+
+                Spacer()
+                PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
+                    coordinator.pop()
+                }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 30)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
+        }
+        .preferredColorScheme(.dark)
+        .navigationTitle(StringLiterals.Setting.notificationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        NotificationTimeSettingView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -25,7 +25,7 @@ struct NotificationTimeSettingView: View {
 
             VStack(spacing: 0) {
                 SettingIntro(
-                    systemImage: "alarm.fill",
+                    symbol: .alarm,
                     headline: StringLiterals.Setting.notificationHeadline,
                     subtitle: StringLiterals.Setting.notificationSubtitle
                 )

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -39,7 +39,7 @@ struct NotificationTimeSettingView: View {
 
                 HStack {
                     Text(StringLiterals.Setting.notificationToggle)
-                        .font(.system(size: 16))
+                        .font(.calloutRegular)
                         .foregroundStyle(.white)
                     Spacer()
                     Toggle("", isOn: $isOn)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct NotificationTimeSettingView: View {
-    let coordinator: AppCoordinator
+    @Environment(\.dismiss) private var dismiss
 
     // 더미 기본값: 오후 09:30
     @State private var time: Date = {
@@ -55,7 +55,7 @@ struct NotificationTimeSettingView: View {
 
                 Spacer()
                 PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
-                    coordinator.pop()
+                    dismiss()
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 30)
@@ -84,7 +84,7 @@ private extension Color {
 #if DEBUG
 #Preview {
     NavigationStack {
-        NotificationTimeSettingView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+        NotificationTimeSettingView()
     }
 }
 #endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -21,7 +21,7 @@ struct NotificationTimeSettingView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E).ignoresSafeArea()
+            Color.backgroundSecondary.ignoresSafeArea()
 
             VStack(spacing: 0) {
                 SettingIntro(

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -33,7 +33,7 @@ struct NotificationTimeSettingView: View {
                 DatePicker("", selection: $time, displayedComponents: .hourAndMinute)
                     .datePickerStyle(.wheel)
                     .labelsHidden()
-                    .tint(Color(hex: 0xFCDF42))
+                    .tint(.yellow60)
                     .environment(\.locale, Locale(identifier: "en_US"))
                     .padding(.top, 83)
 
@@ -44,12 +44,13 @@ struct NotificationTimeSettingView: View {
                     Spacer()
                     Toggle("", isOn: $isOn)
                         .labelsHidden()
-                        .tint(Color(hex: 0xFFCB24))
+                        .tint(.yellow20)
                 }
                 .padding(.leading, 20)
                 .padding(.trailing, 12)
                 .frame(height: 58)
-                .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 26))
+                // Backgrounds/Tertiary (iOS 시스템색)
+                .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 26))
                 .padding(.horizontal, 20)
                 .padding(.top, 77)
 
@@ -66,18 +67,6 @@ struct NotificationTimeSettingView: View {
         .navigationTitle(StringLiterals.Setting.notificationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
-    }
-}
-
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
@@ -9,13 +9,13 @@ import SwiftUI
 
 /// 아이콘 + 헤드라인 + 서브타이틀 (좌측 정렬)
 struct SettingIntro: View {
-    let systemImage: String
+    let symbol: SymbolLiterals
     let headline: String
     let subtitle: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: 36) {
-            Image(systemName: systemImage)
+            Image(symbol)
                 .font(.system(size: 28))
                 // Labels/Tertiary (iOS 시스템색)
                 .foregroundStyle(Color(.tertiaryLabel))

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
@@ -22,11 +22,11 @@ struct SettingIntro: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 Text(headline)
-                    .font(.system(size: 26, weight: .semibold))
+                    .font(.title3SemiBold)
                     .foregroundStyle(.white)
 
                 Text(subtitle)
-                    .font(.system(size: 18, weight: .light))
+                    .font(.body2Light)
                     // Labels/Secondary (iOS 시스템색)
                     .foregroundStyle(Color(.secondaryLabel))
             }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
@@ -17,7 +17,8 @@ struct SettingIntro: View {
         VStack(alignment: .leading, spacing: 36) {
             Image(systemName: systemImage)
                 .font(.system(size: 28))
-                .foregroundStyle(Color(white: 0.92).opacity(0.3))
+                // Labels/Tertiary (iOS 시스템색)
+                .foregroundStyle(Color(.tertiaryLabel))
 
             VStack(alignment: .leading, spacing: 12) {
                 Text(headline)
@@ -26,7 +27,8 @@ struct SettingIntro: View {
 
                 Text(subtitle)
                     .font(.system(size: 18, weight: .light))
-                    .foregroundStyle(Color(white: 0.92).opacity(0.7))
+                    // Labels/Secondary (iOS 시스템색)
+                    .foregroundStyle(Color(.secondaryLabel))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsComponents.swift
@@ -1,0 +1,36 @@
+//
+//  SettingsComponents.swift
+//  LivingStory-iOS
+//
+//  설정 하위 화면 공용 컴포넌트 (헤더 / 인트로)
+//
+
+import SwiftUI
+
+/// 아이콘 + 헤드라인 + 서브타이틀 (좌측 정렬)
+struct SettingIntro: View {
+    let systemImage: String
+    let headline: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 36) {
+            Image(systemName: systemImage)
+                .font(.system(size: 28))
+                .foregroundStyle(Color(white: 0.92).opacity(0.3))
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(headline)
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(.white)
+
+                Text(subtitle)
+                    .font(.system(size: 18, weight: .light))
+                    .foregroundStyle(Color(white: 0.92).opacity(0.7))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsFlowView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsFlowView.swift
@@ -1,0 +1,52 @@
+//
+//  SettingsFlowView.swift
+//  LivingStory-iOS
+//
+//  설정 플로우 — UIKit 코디네이터 위에서 "이 화면들만" SwiftUI NavigationStack이 네비바를 소유.
+//  (UIKit UIHostingController 호스팅에선 native large 타이틀의 스크롤↔바 연동이 깨져
+//   진입 시 inline → 당겨야 large로 "뵹" 튀는 글리치가 생김. SwiftUI가 바를 소유하면 해결.)
+//  추후 앱 전체를 SwiftUI 라우터로 전환하면 이 격리는 통합/제거 예정.
+//
+
+import SwiftUI
+import UIKit
+
+/// 설정 하위 화면 경로
+enum SettingsRoute: Hashable {
+    case childAge
+    case notification
+    case home
+}
+
+struct SettingsFlowView: View {
+    let coordinator: AppCoordinator
+    @State private var path: [SettingsRoute] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            SettingsView(coordinator: coordinator, path: $path)
+                .navigationDestination(for: SettingsRoute.self) { route in
+                    switch route {
+                    case .childAge:     ChildAgeSettingView()
+                    case .notification: NotificationTimeSettingView()
+                    case .home:         HomeSelectionView()
+                    }
+                }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+/// 화면 표시 동안만 UIKit 네비바를 숨김(아래 SwiftUI NavigationStack이 바를 소유) → 이탈 시 복원.
+/// 복원이 없으면 설정에서 빠져나간 뒤 StatisticsView 등 UIKit 네비바를 쓰는 화면의 바가 사라짐.
+final class NavBarHiddenHostingController<Content: View>: UIHostingController<Content> {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     let coordinator: AppCoordinator
+    @Binding var path: [SettingsRoute]
 
     // TODO: 실제 설정값 연동 (현재 더미)
     private let childAge = "7살"
@@ -17,46 +18,56 @@ struct SettingsView: View {
     private let appVersion = "1.0.0"
 
     var body: some View {
-        ZStack {
-            Color.backgroundSecondary.ignoresSafeArea()
-
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    section(StringLiterals.Setting.childInfoSection) {
-                        SettingsRow(title: StringLiterals.Setting.childAge, value: childAge) {
-                            coordinator.showChildAgeSetting()
-                        }
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                section(StringLiterals.Setting.childInfoSection) {
+                    SettingsRow(title: StringLiterals.Setting.childAge, value: childAge) {
+                        path.append(.childAge)
                     }
+                }
 
-                    section(StringLiterals.Setting.notificationSection) {
-                        SettingsRow(title: StringLiterals.Setting.notificationTime, value: notificationTime) {
-                            coordinator.showNotificationTimeSetting()
-                        }
+                section(StringLiterals.Setting.notificationSection) {
+                    SettingsRow(title: StringLiterals.Setting.notificationTime, value: notificationTime) {
+                        path.append(.notification)
                     }
+                }
 
-                    section(StringLiterals.Setting.environmentSection) {
-                        SettingsRow(title: StringLiterals.Setting.home, value: homeName) {
-                            coordinator.showHomeSelection()
-                        }
+                section(StringLiterals.Setting.environmentSection) {
+                    SettingsRow(title: StringLiterals.Setting.home, value: homeName) {
+                        path.append(.home)
                     }
+                }
 
-                    section(StringLiterals.Setting.appInfoSection) {
-                        VStack(spacing: 0) {
-                            SettingsRow(title: StringLiterals.Setting.version, value: appVersion, showChevron: false)
-                            Divider().overlay(Color.white.opacity(0.08)).padding(.horizontal, 18)
-                            SettingsRow(title: StringLiterals.Setting.privacy) {
-                                // TODO: 개인정보처리방침 연결
-                            }
+                section(StringLiterals.Setting.appInfoSection) {
+                    VStack(spacing: 0) {
+                        SettingsRow(title: StringLiterals.Setting.version, value: appVersion, showChevron: false)
+                        Divider().overlay(Color.white.opacity(0.08)).padding(.horizontal, 18)
+                        SettingsRow(title: StringLiterals.Setting.privacy) {
+                            // TODO: 개인정보처리방침 연결
                         }
                     }
                 }
-                .padding(.bottom, 24)
             }
+            .padding(.bottom, 24)
         }
+        // 배경은 .background로 풀블리드, ScrollView는 세이프에어리어 준수 → Large 타이틀 정상 동작
+        .background(Color.backgroundSecondary.ignoresSafeArea())
         .preferredColorScheme(.dark)
         .navigationTitle(StringLiterals.Setting.title)
         .navigationBarTitleDisplayMode(.large)
         .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbar {
+            // 설정 루트 → 설정 빠져나가기(UIKit pop으로 Statistics 복귀)
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    coordinator.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+            }
+        }
     }
 
     // MARK: - Section
@@ -131,7 +142,10 @@ private extension Color {
 #if DEBUG
 #Preview {
     NavigationStack {
-        SettingsView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+        SettingsView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            path: .constant([])
+        )
     }
 }
 #endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E).ignoresSafeArea()
+            Color.backgroundSecondary.ignoresSafeArea()
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -1,0 +1,137 @@
+//
+//  SettingsView.swift
+//  LivingStory-iOS
+//
+//  설정 메인 (디자인 897-4792) — 현재 UI만, 값 더미
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    let coordinator: AppCoordinator
+
+    // TODO: 실제 설정값 연동 (현재 더미)
+    private let childAge = "7살"
+    private let notificationTime = "오후 09:30"
+    private let homeName = "서울 집"
+    private let appVersion = "1.0.0"
+
+    var body: some View {
+        ZStack {
+            Color(hex: 0x1C1C1E).ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    section(StringLiterals.Setting.childInfoSection) {
+                        SettingsRow(title: StringLiterals.Setting.childAge, value: childAge) {
+                            coordinator.showChildAgeSetting()
+                        }
+                    }
+
+                    section(StringLiterals.Setting.notificationSection) {
+                        SettingsRow(title: StringLiterals.Setting.notificationTime, value: notificationTime) {
+                            coordinator.showNotificationTimeSetting()
+                        }
+                    }
+
+                    section(StringLiterals.Setting.environmentSection) {
+                        SettingsRow(title: StringLiterals.Setting.home, value: homeName) {
+                            coordinator.showHomeSelection()
+                        }
+                    }
+
+                    section(StringLiterals.Setting.appInfoSection) {
+                        VStack(spacing: 0) {
+                            SettingsRow(title: StringLiterals.Setting.version, value: appVersion, showChevron: false)
+                            Divider().overlay(Color.white.opacity(0.08)).padding(.horizontal, 18)
+                            SettingsRow(title: StringLiterals.Setting.privacy) {
+                                // TODO: 개인정보처리방침 연결
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 24)
+            }
+        }
+        .preferredColorScheme(.dark)
+        .navigationTitle(StringLiterals.Setting.title)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+
+    // MARK: - Section
+
+    private func section<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 14))
+                .foregroundStyle(Color(white: 0.92).opacity(0.4))
+                .padding(.leading, 4)
+
+            content()
+                .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 18))
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+    }
+}
+
+// MARK: - Settings Row
+
+private struct SettingsRow: View {
+    let title: String
+    var value: String? = nil
+    var showChevron: Bool = true
+    var action: (() -> Void)? = nil
+
+    var body: some View {
+        Button {
+            action?()
+        } label: {
+            HStack(spacing: 8) {
+                Text(title)
+                    .font(.system(size: 16))
+                    .foregroundStyle(.white)
+                Spacer()
+                if let value {
+                    Text(value)
+                        .font(.system(size: 16))
+                        .foregroundStyle(Color(white: 0.92).opacity(0.5))
+                }
+                if showChevron {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color(hex: 0xFFCB24))
+                }
+            }
+            .padding(.horizontal, 18)
+            .frame(height: 56)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(action == nil)
+    }
+}
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        SettingsView(coordinator: AppCoordinator(navigationController: UINavigationController()))
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -78,7 +78,7 @@ struct SettingsView: View {
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
-                .font(.system(size: 14))
+                .font(.labelRegular)
                 .foregroundStyle(Color(white: 0.92).opacity(0.4))
                 .padding(.leading, 4)
 
@@ -105,12 +105,12 @@ private struct SettingsRow: View {
         } label: {
             HStack(spacing: 8) {
                 Text(title)
-                    .font(.system(size: 16))
+                    .font(.calloutRegular)
                     .foregroundStyle(.white)
                 Spacer()
                 if let value {
                     Text(value)
-                        .font(.system(size: 16))
+                        .font(.calloutRegular)
                         .foregroundStyle(Color(white: 0.92).opacity(0.5))
                 }
                 if showChevron {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -83,7 +83,8 @@ struct SettingsView: View {
                 .padding(.leading, 4)
 
             content()
-                .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 18))
+                // Backgrounds/Tertiary (iOS 시스템색)
+                .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 26))
         }
         .padding(.horizontal, 20)
         .padding(.top, 20)
@@ -115,7 +116,7 @@ private struct SettingsRow: View {
                 if showChevron {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Color(hex: 0xFFCB24))
+                        .foregroundStyle(.yellow20)
                 }
             }
             .padding(.horizontal, 18)
@@ -124,18 +125,6 @@ private struct SettingsRow: View {
         }
         .buttonStyle(.plain)
         .disabled(action == nil)
-    }
-}
-
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -62,7 +62,7 @@ struct SettingsView: View {
                 Button {
                     coordinator.pop()
                 } label: {
-                    Image(systemName: "chevron.left")
+                    Image(.back)
                         .font(.system(size: 17, weight: .semibold))
                         .foregroundStyle(.white)
                 }
@@ -114,7 +114,7 @@ private struct SettingsRow: View {
                         .foregroundStyle(Color(white: 0.92).opacity(0.5))
                 }
                 if showChevron {
-                    Image(systemName: "chevron.right")
+                    Image(.forward)
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.yellow20)
                 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -59,7 +59,7 @@ struct StatisticsView: View {
                 Button {
                     coordinator.showSettings()
                 } label: {
-                    Image(systemName: "gearshape.fill")
+                    Image(.settingsFill)
                         .foregroundStyle(.white)
                 }
             }
@@ -80,7 +80,7 @@ struct StatisticsView: View {
 
     private var flameBadge: some View {
         HStack(spacing: 4) {
-            Image(systemName: "flame.fill")
+            Image(.flame)
                 .font(.system(size: 16))
                 .foregroundStyle(
                     LinearGradient(
@@ -135,7 +135,7 @@ struct StatisticsView: View {
                     .font(.body2Regular)
                     .foregroundStyle(.white)
                 Spacer()
-                Image(systemName: "chevron.right")
+                Image(.forward)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(Color(white: 0.92).opacity(0.4))
             }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -23,7 +23,7 @@ struct StatisticsView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: 0x1C1C1E).ignoresSafeArea()
+            Color.backgroundSecondary.ignoresSafeArea()
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -237,40 +237,6 @@ private struct StatBookThumbnail: View {
     }
 }
 
-// MARK: - Stat Card (현재 미사용 — 추후 재사용 대비 보존)
-
-struct StatCard: View {
-    let icon: String
-    let title: String
-    let value: String
-    var isWide: Bool = false
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            Image(systemName: icon)
-            if !isWide {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(title).font(.subheadlineRegular)
-                    Text(value).font(.subheadlineEmphasized)
-                }
-            } else {
-                HStack {
-                    Text(title).font(.subheadlineRegular)
-                    Spacer()
-                    Text(value).font(.subheadlineEmphasized)
-                }
-            }
-        }
-        .padding(.vertical, 14)
-        .padding(.leading, 10)
-        .padding(.trailing, 14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: 14))
-        .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
-    }
-}
-
 // MARK: - Color Helper
 
 private extension Color {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -71,7 +71,7 @@ struct StatisticsView: View {
     private var titleRow: some View {
         HStack(alignment: .firstTextBaseline) {
             Text(StringLiterals.My.summaryTitle)
-                .font(.system(size: 28, weight: .bold))
+                .font(.title1Emphasized)
                 .foregroundStyle(.white)
             Spacer()
             flameBadge
@@ -90,7 +90,7 @@ struct StatisticsView: View {
                     )
                 )
             Text("\(flameCount)")
-                .font(.system(size: 18, weight: .semibold))
+                .font(.body2SemiBold)
                 .foregroundStyle(.white)
         }
     }
@@ -101,18 +101,18 @@ struct StatisticsView: View {
         ZStack(alignment: .topLeading) {
             VStack(alignment: .leading, spacing: 0) {
                 Text(monthLabel)
-                    .font(.system(size: 16))
+                    .font(.calloutRegular)
                     .foregroundStyle(Color(white: 0.92).opacity(0.6))
                 Text(StringLiterals.My.monthlyReadIntro)
-                    .font(.system(size: 20, weight: .regular))
+                    .font(.body1Regular)
                     .foregroundStyle(.white)
                     .padding(.top, 12)
 
                 HStack(alignment: .firstTextBaseline, spacing: 2) {
                     Text("\(monthlyCount)")
-                        .font(.system(size: 56, weight: .medium))
+                        .font(.largeTitleMedium)
                     Text(StringLiterals.My.readingUnit)
-                        .font(.system(size: 30, weight: .medium))
+                        .font(.title2Medium)
                 }
                 .foregroundStyle(.white)
                 .padding(.top, 16)
@@ -129,10 +129,10 @@ struct StatisticsView: View {
         VStack(alignment: .leading, spacing: 24) {
             HStack(spacing: 8) {
                 Text(StringLiterals.My.totalReadBooks)
-                    .font(.system(size: 18, weight: .medium))
+                    .font(.body2Medium)
                     .foregroundStyle(.white)
                 Text("\(totalReadCount)")
-                    .font(.system(size: 18, weight: .regular))
+                    .font(.body2Regular)
                     .foregroundStyle(.white)
                 Spacer()
                 Image(systemName: "chevron.right")
@@ -211,7 +211,7 @@ private struct StatBookThumbnail: View {
                 .clipShape(RoundedRectangle(cornerRadius: 4))
 
             Text(title)
-                .font(.system(size: 14, weight: .medium))
+                .font(.labelMedium)
                 .foregroundStyle(.white)
                 .opacity(0.7)
                 .lineLimit(1)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -4,6 +4,8 @@
 //
 //  📱 담당: 이토 (SwiftUI)
 //
+//  내 독서 요약 (디자인 897-4729) — 현재 UI만, 데이터 더미
+//
 
 import SwiftUI
 
@@ -12,61 +14,212 @@ struct StatisticsView: View {
     let coordinator: AppCoordinator
     let repository: ReadingSessionRepositoryProtocol
 
-    var body: some View {
-            VStack(spacing: 16) {
-                ReadingLogCalendar(readDates: (try? repository.fetchReadDates()) ?? [])
-                    .padding(.top, 25)
-                statsSection
+    // TODO: 실제 데이터 연동 (현재 전부 더미)
+    private let flameCount = 12
+    private let monthLabel = "2026년 10월"
+    private let monthlyCount = 23
+    private let totalReadCount = 18
+    private let dummyBooks: [BookProfileModel] = [.mock, .mockISBN, .mock, .mockISBN, .mock]
 
-                Spacer()
+    var body: some View {
+        ZStack {
+            Color(hex: 0x1C1C1E).ignoresSafeArea()
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    titleRow
+                        .padding(.horizontal, 20)
+                        .padding(.top, 4)
+
+                    monthlySummary
+                        .padding(.horizontal, 20)
+                        .padding(.top, 40)
+
+                    MultiSelectCalendarView()
+                        .padding(.top, 88)
+
+                    Divider()
+                        .overlay(Color.white.opacity(0.1))
+                        .padding(.horizontal, 8)
+
+                    totalBooksSection
+                        .padding(.top, 24)
+                        .padding(.bottom, 24)
+                }
             }
-            .padding(.horizontal, 20)
-            .background(
-                RadialGradient(
-                    colors: [
-                        Color(red: 1, green: 0.77, blue: 0.016).opacity(0.2),
-                        Color(red: 1, green: 0.77, blue: 0.016).opacity(0)
-                    ],
-                    center: .center,
-                    startRadius: 0,
-                    endRadius: 305
-                )
-                .frame(width: 589, height: 610)
-                .offset(y: 150)
-            )
-        .navigationTitle(StringLiterals.My.title)
-        .navigationBarTitleDisplayMode(.large)
+        }
+        .preferredColorScheme(.dark)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .toolbar {
-            ToolbarItem {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    // setting시트 열리는 로직
+                    // TODO: 설정 시트
                 } label: {
-                    Image(.settings)
+                    Image(systemName: "gearshape.fill")
+                        .foregroundStyle(.white)
                 }
             }
         }
     }
 
-    private var totalTimeString: String {
-        let totalSeconds = (try? repository.fetchTotalSeconds()) ?? 0
-        return ReadingTimeFormatter.format(totalSeconds: totalSeconds)
+    // MARK: - Title + Streak (디자인 Title and Subtitle 영역)
+
+    private var titleRow: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(StringLiterals.My.summaryTitle)
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.white)
+            Spacer()
+            flameBadge
+        }
     }
 
-    // MARK: - Subviews
+    private var flameBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "flame.fill")
+                .font(.system(size: 16))
+                .foregroundStyle(
+                    LinearGradient(
+                        colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+            Text("\(flameCount)")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.white)
+        }
+    }
 
-    private var statsSection: some View {
-            VStack(spacing: 12) {
-                HStack(spacing: 10) {
-                    StatCard(icon: SymbolLiterals.calendar.rawValue, title: StringLiterals.My.monthlyBookCount, value: "\((try? repository.fetchMonthlyBookCount()) ?? 0)\(StringLiterals.My.readingUnit)")
-                    StatCard(icon: SymbolLiterals.books.rawValue, title: StringLiterals.My.totalBookCount, value: "\((try? repository.fetchTotalBookCount()) ?? 0)\(StringLiterals.My.bookUnit)")
+    // MARK: - Monthly Summary (물결 그래프)
+
+    private var monthlySummary: some View {
+        ZStack(alignment: .topLeading) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(monthLabel)
+                    .font(.system(size: 16))
+                    .foregroundStyle(Color(white: 0.92).opacity(0.6))
+                Text(StringLiterals.My.monthlyReadIntro)
+                    .font(.system(size: 20, weight: .regular))
+                    .foregroundStyle(.white)
+                    .padding(.top, 12)
+
+                HStack(alignment: .firstTextBaseline, spacing: 2) {
+                    Text("\(monthlyCount)")
+                        .font(.system(size: 56, weight: .medium))
+                    Text(StringLiterals.My.readingUnit)
+                        .font(.system(size: 30, weight: .medium))
                 }
-                StatCard(icon: SymbolLiterals.clock.rawValue, title: StringLiterals.My.totalReadingTime, value: totalTimeString, isWide: true)
-                Spacer()
+                .foregroundStyle(.white)
+                .padding(.top, 16)
             }
+        }
+    }
+
+    // MARK: - Total Books
+
+    private var totalBooksSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            HStack(spacing: 8) {
+                Text(StringLiterals.My.totalReadBooks)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.white)
+                Text("\(totalReadCount)")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundStyle(.white)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color(white: 0.92).opacity(0.4))
+            }
+            .padding(.horizontal, 20)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(Array(dummyBooks.enumerated()), id: \.offset) { _, book in
+                        StatBookThumbnail(coverURL: book.bookCoverImageURL, title: book.bookTitle)
+                    }
+                }
+                .padding(.horizontal, 20)
+            }
+        }
     }
 }
 
-// MARK: - Subviews
+// MARK: - Summary Wave (장식용 그라데이션 물결)
+
+private struct SummaryWave: View {
+    var body: some View {
+        GeometryReader { geo in
+            let w = geo.size.width
+            let h = geo.size.height
+            Path { path in
+                path.move(to: CGPoint(x: 0, y: h * 0.6))
+                path.addCurve(
+                    to: CGPoint(x: w * 0.5, y: h * 0.55),
+                    control1: CGPoint(x: w * 0.2, y: h * 0.5),
+                    control2: CGPoint(x: w * 0.3, y: h * 0.7)
+                )
+                path.addCurve(
+                    to: CGPoint(x: w, y: h * 0.05),
+                    control1: CGPoint(x: w * 0.72, y: h * 0.38),
+                    control2: CGPoint(x: w * 0.82, y: h * 0.1)
+                )
+            }
+            .stroke(
+                LinearGradient(
+                    colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68), Color(hex: 0x5AC8E8)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                ),
+                style: StrokeStyle(lineWidth: 10, lineCap: .round)
+            )
+        }
+    }
+}
+
+// MARK: - Book Thumbnail
+
+private struct StatBookThumbnail: View {
+    let coverURL: URL?
+    let title: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            cover
+                .frame(width: 72, height: 96)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+            Text(title)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.white)
+                .opacity(0.7)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 72, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var cover: some View {
+        if let coverURL {
+            AsyncImage(url: coverURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    Color(hex: 0x2C2C2E)
+                }
+            }
+        } else {
+            Color(hex: 0x2C2C2E)
+        }
+    }
+}
+
+// MARK: - Stat Card (현재 미사용 — 추후 재사용 대비 보존)
 
 struct StatCard: View {
     let icon: String
@@ -79,18 +232,14 @@ struct StatCard: View {
             Image(systemName: icon)
             if !isWide {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(.labelRegular)
-                    Text(value)
-                        .font(.calloutSemiBold)
+                    Text(title).font(.subheadlineRegular)
+                    Text(value).font(.subheadlineEmphasized)
                 }
             } else {
                 HStack {
-                    Text(title)
-                        .font(.labelRegular)
+                    Text(title).font(.subheadlineRegular)
                     Spacer()
-                    Text(value)
-                        .font(.calloutSemiBold)
+                    Text(value).font(.subheadlineEmphasized)
                 }
             }
         }
@@ -103,3 +252,40 @@ struct StatCard: View {
         .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
     }
 }
+
+// MARK: - Color Helper
+
+private extension Color {
+    init(hex: UInt) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+private struct PreviewStatsRepository: ReadingSessionRepositoryProtocol {
+    func saveSession(_ session: ReadingSessionProfile, bookISBN: String) throws {}
+    func fetchAllSessions() throws -> [ReadingSessionProfile] { [] }
+    func findSession(by id: UUID) throws -> ReadingSessionProfile? { nil }
+    func deleteSession(by id: UUID) throws {}
+    func fetchTodaySessions() throws -> [ReadingSessionProfile] { [] }
+    func fetchMonthlyBookCount() throws -> Int { 23 }
+    func fetchTotalBookCount() throws -> Int { 18 }
+    func fetchTotalSeconds() throws -> Int { 0 }
+    func fetchReadDates() throws -> Set<DateComponents> { [] }
+}
+
+#Preview {
+    NavigationStack {
+        StatisticsView(
+            coordinator: AppCoordinator(navigationController: UINavigationController()),
+            repository: PreviewStatsRepository()
+        )
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -84,7 +84,7 @@ struct StatisticsView: View {
                 .font(.system(size: 16))
                 .foregroundStyle(
                     LinearGradient(
-                        colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68)],
+                        colors: [.yellow20, .green0],
                         startPoint: .top,
                         endPoint: .bottom
                     )
@@ -163,7 +163,7 @@ private struct SummaryWave: View {
             .trim(from: 0, to: progress)
             .stroke(
                 LinearGradient(
-                    colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68), Color(hex: 0x5AC8E8)],
+                    colors: [.yellow20, .green0, Color(hex: 0x5AC8E8)],
                     startPoint: .leading,
                     endPoint: .trailing
                 ),
@@ -228,11 +228,11 @@ private struct StatBookThumbnail: View {
                 case .success(let image):
                     image.resizable().scaledToFill()
                 default:
-                    Color(hex: 0x2C2C2E)
+                    Color(.tertiarySystemBackground)
                 }
             }
         } else {
-            Color(hex: 0x2C2C2E)
+            Color(.tertiarySystemBackground)
         }
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -45,7 +45,7 @@ struct StatisticsView: View {
                         .padding(.horizontal, 8)
 
                     totalBooksSection
-                        .padding(.top, 24)
+                        .padding(.top, 34)
                         .padding(.bottom, 24)
                 }
             }
@@ -57,7 +57,7 @@ struct StatisticsView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    // TODO: 설정 시트
+                    coordinator.showSettings()
                 } label: {
                     Image(systemName: "gearshape.fill")
                         .foregroundStyle(.white)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -32,11 +32,13 @@ struct StatisticsView: View {
                         .padding(.top, 4)
 
                     monthlySummary
-                        .padding(.horizontal, 20)
                         .padding(.top, 40)
+                        .background(alignment: .top) {
+                            SummaryWave()
+                                .frame(maxWidth: .infinity)
+                        }
 
                     MultiSelectCalendarView()
-                        .padding(.top, 88)
 
                     Divider()
                         .overlay(Color.white.opacity(0.1))
@@ -115,7 +117,10 @@ struct StatisticsView: View {
                 .foregroundStyle(.white)
                 .padding(.top, 16)
             }
+            .padding(.horizontal, 20)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, 88)
     }
 
     // MARK: - Total Books
@@ -151,32 +156,45 @@ struct StatisticsView: View {
 // MARK: - Summary Wave (장식용 그라데이션 물결)
 
 private struct SummaryWave: View {
+    @State private var progress: CGFloat = 0
+
     var body: some View {
-        GeometryReader { geo in
-            let w = geo.size.width
-            let h = geo.size.height
-            Path { path in
-                path.move(to: CGPoint(x: 0, y: h * 0.6))
-                path.addCurve(
-                    to: CGPoint(x: w * 0.5, y: h * 0.55),
-                    control1: CGPoint(x: w * 0.2, y: h * 0.5),
-                    control2: CGPoint(x: w * 0.3, y: h * 0.7)
-                )
-                path.addCurve(
-                    to: CGPoint(x: w, y: h * 0.05),
-                    control1: CGPoint(x: w * 0.72, y: h * 0.38),
-                    control2: CGPoint(x: w * 0.82, y: h * 0.1)
-                )
-            }
+        WaveShape()
+            .trim(from: 0, to: progress)
             .stroke(
                 LinearGradient(
                     colors: [Color(hex: 0xFFCB24), Color(hex: 0xBFEE68), Color(hex: 0x5AC8E8)],
                     startPoint: .leading,
                     endPoint: .trailing
                 ),
-                style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                style: StrokeStyle(lineWidth: 13, lineCap: .round, lineJoin: .round)
             )
-        }
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1.1)) {
+                    progress = 1
+                }
+            }
+    }
+}
+
+/// 좌하단(낮음) → 우상단(높음)으로 솟는 물결 라인
+private struct WaveShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+        var path = Path()
+        path.move(to: CGPoint(x: 0, y: h * 0.72))
+        path.addCurve(
+            to: CGPoint(x: w * 0.42, y: h * 0.86),
+            control1: CGPoint(x: w * 0.13, y: h * 0.66),
+            control2: CGPoint(x: w * 0.27, y: h * 0.92)
+        )
+        path.addCurve(
+            to: CGPoint(x: w, y: h * 0.18),
+            control1: CGPoint(x: w * 0.62, y: h * 0.80),
+            control2: CGPoint(x: w * 0.82, y: h * 0.26)
+        )
+        return path
     }
 }
 


### PR DESCRIPTION
Closes #78

## 📝 Summary
디자인 전면 개편 2단계 — `ito` 작업 브랜치의 화면 리디자인을 정리해 반영하고, 독서/설정 플로우의 네비게이션 구조를 표준화하며, 하드코딩된 색·폰트·심볼·문구를 Consts 토큰으로 치환했습니다. PO-84(Atomic 디자인 시스템) 위에서 진행했습니다.

## 🖼 화면 리디자인
- 내 독서 요약 화면 리디자인 + 독서 기록 캘린더 추가
- 월간 그래프 물결 라인 애니메이션
- 책 읽기 결과창 리디자인 + 책 쌓기 애니메이션
- 책 읽기 완료 화면 리디자인, 대화 나누기 화면 분리(아코디언)
- 설정 화면 추가(메인 · 아이 나이 · 알림 시간 · 집 선택) 및 요약 화면에서 진입 연결

## 🧭 네비게이션 구조 변경
- 독서 플로우의 커스텀 헤더를 iOS 표준 툴바로 전환. 네비바 배경은 숨기고, 타이틀은 `ToolbarItem(.principal)`에 흰색 텍스트로 직접 렌더(앱 라이트 고정 시 시스템 타이틀이 검정으로 나오는 문제 회피).
- 설정 플로우를 SwiftUI `NavigationStack`으로 격리.

## 🎨 디자인 토큰화 (Consts)
- 색: `0xFFCB24 → .yellow20`, `0xBFEE68 → .green0`, `0xFCDF42 → .yellow60`(Atomic 에셋). 카드 배경 `0x2C2C2E → Color(.tertiarySystemBackground)`(Backgrounds/Tertiary), 라벨 `Color(.tertiaryLabel)`/`Color(.secondaryLabel)`(iOS 시스템색). 1회용 장식색은 hex 유지.
- 폰트: 텍스트의 `.system(size:weight:)`를 `FontLiterals`(Pretendard) 토큰으로 치환. SF Symbol 아이콘 크기는 타이포가 아니므로 `.system` 유지. 타입스케일에 없는 사이즈는 신규 토큰 추가(`display1~3`, `title1Emphasized`, `footnoteEmphasized`, `buttonMedium`, `buttonSmallMedium`).
- 심볼: `Image(systemName:)`를 `Image(.case)`로 치환. 컴포넌트 파라미터(`EnvControlRow`, `SettingIntro`)도 `String`에서 `SymbolLiterals`로 변경. 신규 케이스 6종(`flame`, `waveform`, `sliderHorizontal`, `settingsFill`, `childHands`, `alarm`).
- 문구: UI 문자열을 `StringLiterals`로 치환(재시도/닫기, 조명·음악·밝기·볼륨·조정, 만/세). 보간값·더미 데이터는 제외.
- 별도 머지: Atomic 컬러셋 값 교정(yellow20 `#FBC928→#FFCB24`, yellow40 `#FCD650→#FFD54D`)은 PO-87(#80)로 develop에 선반영.

## 🎚 인터랙션
- 독서 중 슬라이더를 네이티브 `Slider`(틱)로 교체, 밝기/볼륨 실시간 연동
- 독서 종료 시 체크마크 그리기 전환 인터랙션

## 🏗 Architecture Decision
**설정 플로우를 SwiftUI NavigationStack으로 격리한 이유**
- 앱은 UIKit `AppCoordinator`(`UINavigationController`) 기반이고, 설정 화면들은 `UIHostingController`로 호스팅된다.
- 이 구성에서 SwiftUI native large title의 "스크롤 ↔ 네비바" 연동이 깨진다. 화면 진입 시 inline 상태로 들어왔다가, 아래로 당기면 large title로 늦게 전환되는 글리치가 발생한다.
- 원인은 large title의 스크롤 추적을 UIKit 네비게이션 컨트롤러가 소유하는데, 호스팅된 SwiftUI 스크롤뷰와 연동이 맞지 않기 때문이다.
- 해결: 설정 플로우 구간만 SwiftUI `NavigationStack`이 네비바를 소유하도록 격리한다. 이 구간 동안에는 `NavBarHiddenHostingController`가 UIKit 네비바를 숨기고, 이탈 시 복원한다. 복원하지 않으면 설정에서 빠져나온 뒤 Statistics 등 UIKit 네비바를 쓰는 화면의 바가 사라진다.
- 범위 한정: 전체 앱을 SwiftUI 라우터로 전환하기 전까지의 국소 격리이며, 라우터 전환 시 통합·제거 예정이다.

**색은 토큰 신설 대신 iOS 시스템색 사용**
- `0x2C2C2E`(Backgrounds/Tertiary), Labels/Tertiary·Secondary는 iOS 시스템색과 값이 일치한다.
- 커스텀 토큰을 추가하지 않고 `Color(.tertiarySystemBackground)` / `Color(.tertiaryLabel)` / `Color(.secondaryLabel)`로 직접 참조해 토큰 중복을 줄였다.

**고아 폰트 사이즈만 신규 토큰화, 아이콘 크기는 비토큰화**
- `.system(size:)`의 상당수는 텍스트가 아니라 SF Symbol 아이콘 크기다. 여기에 Pretendard 타이포 토큰을 적용하면 의미가 맞지 않으므로 `.system` 유지.
- 텍스트 중 기존 토큰에 없는 사이즈(66/28/22/28bold/13sb/17/15)만 `FontLiterals`에 신규 토큰으로 추가했다.

## 👀 Review Notes
- 파일별 `private Color(hex:)` 확장은 1회용 hex가 남은 파일만 유지, 전부 토큰화된 파일은 제거했다.
- `Color(white:0.92).opacity(0.4/0.5/0.6)`는 iOS 시스템 라벨 색과 정확히 일치하지 않아 이번 범위에서 제외(과잉 치환 방지).
- 설정 화면 값(`7살`, `서울 집` 등)은 추후 실데이터 연동 자리(TODO)라 문구 토큰화에서 제외.
- 커밋은 색/폰트/심볼/문구 4건으로 분리해 리뷰·롤백이 용이하다.

## ✅ Test
- [ ] 빌드 확인 (Pretendard·에셋 심볼 미적용 시 nil 크래시이므로 빌드로 검증됨)
- [ ] 독서 플로우(세팅 → 독서 → 완료 → 대화 → 결과) 회귀 점검
- [ ] 설정 플로우 진입/이탈 시 네비바 정상 동작(large title 글리치 없음, 이탈 후 Statistics 바 복원)
- [ ] 통계/설정 화면 색·폰트·심볼 표시 점검
