### PR TITLE
[Feature] [PO-89] 통계·달력 실데이터 연결 + 사용자 설정값 UserDefaults 저장

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/MultiSelectCalendarView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/MultiSelectCalendarView.swift
@@ -15,24 +15,29 @@ import SwiftUI
 
 struct MultiSelectCalendarView: View {
 
-    /// 표시 중인 달 (더미: 2025년 4월)
-    @State private var month: Date = {
-        var c = DateComponents()
-        c.year = 2025; c.month = 4; c.day = 1
-        return Calendar(identifier: .gregorian).date(from: c) ?? Date()
-    }()
+    /// 책 읽은 날짜(표시 전용). 표시 중인 달에 해당하는 날만 하이라이트한다.
+    private let readDates: Set<DateComponents>
+    /// 오늘 날짜 — 표시 월이 '오늘의 달'일 때만 초록 그라데이션 강조.
+    private let today: Date
+    /// 과거 슬라이드 하한(최초 독서월의 1일). nil이면 이번 달 이전으로 못 간다.
+    private let minMonth: Date?
 
-    /// 책 읽은 날 — 더미 (데이터 표시 전용, 탭으로 바뀌지 않음)
-    private let readDays: Set<Int> = [8, 9, 10, 12, 14, 15]
-
-    /// 오늘(초록 강조) — 더미
-    private let todayDay = 20
-
+    /// 표시 중인 달 — 처음엔 이번 달.
+    @State private var month: Date
     @State private var showMonthPicker = false
 
     private var cal: Calendar { Calendar(identifier: .gregorian) }
     private let weekdays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 8.83), count: 7)
+
+    init(readDates: Set<DateComponents>, today: Date = Date(), minMonth: Date? = nil) {
+        self.readDates = readDates
+        self.today = today
+        self.minMonth = minMonth
+        let cal = Calendar(identifier: .gregorian)
+        let startOfThisMonth = cal.date(from: cal.dateComponents([.year, .month], from: today)) ?? today
+        _month = State(initialValue: startOfThisMonth)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -45,15 +50,16 @@ struct MultiSelectCalendarView: View {
         .gesture(
             DragGesture(minimumDistance: 24)
                 .onEnded { value in
-                    if value.translation.width < -40 {
+                    // 미래(다음 달)는 이번 달까지, 과거(이전 달)는 최초 독서월까지만 이동 가능.
+                    if value.translation.width < -40, canGoNext {
                         withAnimation(.easeInOut(duration: 0.2)) { changeMonth(by: 1) }
-                    } else if value.translation.width > 40 {
+                    } else if value.translation.width > 40, canGoPrev {
                         withAnimation(.easeInOut(duration: 0.2)) { changeMonth(by: -1) }
                     }
                 }
         )
         .sheet(isPresented: $showMonthPicker) {
-            MonthYearPickerSheet(month: $month)
+            MonthYearPickerSheet(month: $month, minMonth: minMonthEffective, maxMonth: maxMonth)
                 .presentationDetents([.height(300)])
                 .presentationDragIndicator(.visible)
         }
@@ -107,8 +113,8 @@ struct MultiSelectCalendarView: View {
     }
 
     private func dayCell(_ day: Int) -> some View {
-        let isToday = day == todayDay
-        let isRead = readDays.contains(day)
+        let isToday = day == todayDayInMonth
+        let isRead = readDaysInMonth.contains(day)
 
         return Text("\(day)")
             .font(.system(size: 20, weight: isToday ? .semibold : .regular))
@@ -151,9 +157,39 @@ struct MultiSelectCalendarView: View {
     }
 
     private func changeMonth(by value: Int) {
-        if let next = cal.date(byAdding: .month, value: value, to: month) {
-            month = next
-        }
+        guard let next = cal.date(byAdding: .month, value: value, to: month) else { return }
+        // 범위 밖이면 무시 (스와이프 가드와 이중 안전장치)
+        guard next >= minMonthEffective, next <= maxMonth else { return }
+        month = next
+    }
+
+    // MARK: - 표시/경계 계산
+
+    private func startOfMonth(_ date: Date) -> Date {
+        cal.date(from: cal.dateComponents([.year, .month], from: date)) ?? date
+    }
+
+    /// 미래 상한 = 이번 달 (독서 기록앱이라 빈 미래월로는 못 넘어간다)
+    private var maxMonth: Date { startOfMonth(today) }
+    /// 과거 하한 = 최초 독서월. 기록 없으면 이번 달.
+    private var minMonthEffective: Date { minMonth ?? maxMonth }
+    private var canGoPrev: Bool { startOfMonth(month) > minMonthEffective }
+    private var canGoNext: Bool { startOfMonth(month) < maxMonth }
+
+    /// 표시 중인 달에 속한 '읽은 날'들의 일(day) 집합
+    private var readDaysInMonth: Set<Int> {
+        let comps = cal.dateComponents([.year, .month], from: month)
+        return Set(readDates.compactMap { d -> Int? in
+            guard d.year == comps.year, d.month == comps.month, let day = d.day else { return nil }
+            return day
+        })
+    }
+
+    /// 표시 중인 달이 '오늘의 달'이면 오늘 일(day), 아니면 nil
+    private var todayDayInMonth: Int? {
+        let m = cal.dateComponents([.year, .month], from: month)
+        let t = cal.dateComponents([.year, .month, .day], from: today)
+        return (m.year == t.year && m.month == t.month) ? t.day : nil
     }
 }
 
@@ -161,6 +197,8 @@ struct MultiSelectCalendarView: View {
 
 private struct MonthYearPickerSheet: View {
     @Binding var month: Date
+    let minMonth: Date
+    let maxMonth: Date
     @Environment(\.dismiss) private var dismiss
 
     @State private var year: Int
@@ -168,11 +206,20 @@ private struct MonthYearPickerSheet: View {
 
     private let cal = Calendar(identifier: .gregorian)
 
-    init(month: Binding<Date>) {
+    init(month: Binding<Date>, minMonth: Date, maxMonth: Date) {
         _month = month
+        self.minMonth = minMonth
+        self.maxMonth = maxMonth
         let cal = Calendar(identifier: .gregorian)
         _year = State(initialValue: cal.component(.year, from: month.wrappedValue))
         _monthNum = State(initialValue: cal.component(.month, from: month.wrappedValue))
+    }
+
+    /// 선택 가능한 연도 범위 = [최초 독서년 … 올해]
+    private var yearRange: ClosedRange<Int> {
+        let lower = cal.component(.year, from: minMonth)
+        let upper = cal.component(.year, from: maxMonth)
+        return lower...max(lower, upper)
     }
 
     var body: some View {
@@ -190,7 +237,7 @@ private struct MonthYearPickerSheet: View {
 
             HStack(spacing: 0) {
                 Picker("연도", selection: $year) {
-                    ForEach(2020...2030, id: \.self) { Text("\($0)년").tag($0) }
+                    ForEach(yearRange, id: \.self) { Text("\($0)년").tag($0) }
                 }
                 .pickerStyle(.wheel)
 
@@ -208,7 +255,9 @@ private struct MonthYearPickerSheet: View {
         comps.year = year
         comps.month = monthNum
         comps.day = 1
-        if let date = cal.date(from: comps) { month = date }
+        guard let date = cal.date(from: comps) else { return }
+        // 범위 밖 선택은 경계로 클램프 (예: 최초 독서월 이전 → 최초 독서월)
+        month = min(max(date, minMonth), maxMonth)
     }
 }
 
@@ -225,9 +274,22 @@ private extension Color {
 }
 
 #Preview {
-    ZStack {
+    let cal = Calendar(identifier: .gregorian)
+    let today = cal.startOfDay(for: Date())
+    // 더미: 이번 달 최근 연속 3일 + 2개월 전 1건(과거 슬라이드 하한 확인)
+    var dates = Set<DateComponents>()
+    for offset in 0...2 {
+        if let d = cal.date(byAdding: .day, value: -offset, to: today) {
+            dates.insert(cal.dateComponents([.year, .month, .day], from: d))
+        }
+    }
+    let past = cal.date(byAdding: .month, value: -2, to: today)!
+    dates.insert(cal.dateComponents([.year, .month, .day], from: past))
+    let minMonth = cal.date(from: cal.dateComponents([.year, .month], from: past))
+
+    return ZStack {
         Color(red: 0.11, green: 0.11, blue: 0.12).ignoresSafeArea()
-        MultiSelectCalendarView()
+        MultiSelectCalendarView(readDates: dates, today: today, minMonth: minMonth)
     }
     .preferredColorScheme(.dark)
 }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Storage/UserData.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Storage/UserData.swift
@@ -11,6 +11,28 @@ struct UserData {
     @UserDefault(key: "hasCompletedOnboarding", defaultValue: false)
     static var hasCompletedOnboarding: Bool
 
+    // MARK: - 사용자 설정값 (직접 입력 → 영속화)
+
+    /// 아이 나이(세). 독서 질문 연령 기준에 사용. 기본 6세(독서 플로우 기본값과 일치).
+    @UserDefault(key: "childAge", defaultValue: 6)
+    static var childAge: Int
+
+    /// 취침 독서 알림 on/off
+    @UserDefault(key: "notificationEnabled", defaultValue: true)
+    static var notificationEnabled: Bool
+
+    /// 알림 시간. 기본 오후 9:30. (실제 알림 등록은 추후 작업)
+    @UserDefault(key: "notificationTime", defaultValue: UserData.defaultNotificationTime)
+    static var notificationTime: Date
+
+    /// 알림 시간 기본값(21:30) — 시/분만 의미 있음
+    private static let defaultNotificationTime: Date = {
+        var comps = DateComponents()
+        comps.hour = 21
+        comps.minute = 30
+        return Calendar.current.date(from: comps) ?? Date()
+    }()
+
     // 마지막으로 적용된 조명 (없으면 hue = -1)
     @UserDefault(key: "lastLightingHue", defaultValue: -1)
     static var lastLightingHue: Int

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ChildAgeSettingView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @State private var age: Int = 13 // 더미 기본값
+    @State private var age: Int = UserData.childAge // 저장값으로 초기화
 
     var body: some View {
         ZStack {
@@ -48,6 +48,7 @@ struct ChildAgeSettingView: View {
                 Spacer()
 
                 PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
+                    UserData.childAge = age
                     dismiss()
                 }
                 .padding(.horizontal, 20)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -10,14 +10,9 @@ import SwiftUI
 struct NotificationTimeSettingView: View {
     @Environment(\.dismiss) private var dismiss
 
-    // 더미 기본값: 오후 09:30
-    @State private var time: Date = {
-        var comps = DateComponents()
-        comps.hour = 21
-        comps.minute = 30
-        return Calendar.current.date(from: comps) ?? Date()
-    }()
-    @State private var isOn = true
+    // 저장값으로 초기화
+    @State private var time: Date = UserData.notificationTime
+    @State private var isOn: Bool = UserData.notificationEnabled
 
     var body: some View {
         ZStack {
@@ -56,6 +51,8 @@ struct NotificationTimeSettingView: View {
 
                 Spacer()
                 PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
+                    UserData.notificationTime = time
+                    UserData.notificationEnabled = isOn
                     dismiss()
                 }
                 .padding(.horizontal, 20)

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -11,11 +11,20 @@ struct SettingsView: View {
     let coordinator: AppCoordinator
     @Binding var path: [SettingsRoute]
 
-    // TODO: 실제 설정값 연동 (현재 더미)
-    private let childAge = "7살"
-    private let notificationTime = "오후 09:30"
+    // 저장값(UserData) 반영 — 루트로 복귀 시 .onAppear가 다시 불려 재로드되므로 즉시 갱신됨
+    @State private var childAge: String = ""
+    @State private var notificationTime: String = ""
+
     private let homeName = "서울 집"
     private let appVersion = "1.0.0"
+
+    /// 오후 09:30 형식
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "a hh:mm"
+        return formatter
+    }()
 
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -52,6 +61,7 @@ struct SettingsView: View {
         }
         // 배경은 .background로 풀블리드, ScrollView는 세이프에어리어 준수 → Large 타이틀 정상 동작
         .background(Color.backgroundSecondary.ignoresSafeArea())
+        .onAppear { reload() }
         .preferredColorScheme(.dark)
         .navigationTitle(StringLiterals.Setting.title)
         .navigationBarTitleDisplayMode(.large)
@@ -68,6 +78,14 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Data
+
+    /// 진입/복귀 시 저장값을 화면 상태로 재로드
+    private func reload() {
+        childAge = "\(UserData.childAge)살"
+        notificationTime = Self.timeFormatter.string(from: UserData.notificationTime)
     }
 
     // MARK: - Section

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -14,12 +14,21 @@ struct StatisticsView: View {
     let coordinator: AppCoordinator
     let repository: ReadingSessionRepositoryProtocol
 
-    // TODO: 실제 데이터 연동 (현재 전부 더미)
-    private let flameCount = 12
-    private let monthLabel = "2026년 10월"
-    private let monthlyCount = 23
-    private let totalReadCount = 18
-    private let dummyBooks: [BookProfileModel] = [.mock, .mockISBN, .mock, .mockISBN, .mock]
+    // 실제 데이터 (onAppear에서 리포지토리로 로드)
+    @State private var flameCount = 0          // 연속 독서일(스트릭) — 저장값이 아니라 읽은 날짜로 계산
+    @State private var monthlyCount = 0         // 이번 달 읽어준 횟수(세션 수)
+    @State private var totalReadCount = 0       // 누적 고유 책 수(중복 제외)
+    @State private var readBooks: [BookProfileModel] = []  // 누적 고유 책 목록(최근 순)
+    @State private var readDates: Set<DateComponents> = [] // 책 읽은 날짜(달력 표시용)
+    @State private var earliestMonth: Date? = nil         // 최초 독서월(달력 과거 슬라이드 하한)
+
+    /// 상단 "이번 달" 라벨 — 현재 월을 한국어로 표시 (yyyy년 M월)
+    private let monthLabel: String = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월"
+        return formatter.string(from: Date())
+    }()
 
     var body: some View {
         ZStack {
@@ -38,7 +47,11 @@ struct StatisticsView: View {
                                 .frame(maxWidth: .infinity)
                         }
 
-                    MultiSelectCalendarView()
+                    MultiSelectCalendarView(
+                        readDates: readDates,
+                        today: Date(),
+                        minMonth: earliestMonth
+                    )
 
                     Divider()
                         .overlay(Color.white.opacity(0.1))
@@ -51,6 +64,7 @@ struct StatisticsView: View {
             }
         }
         .preferredColorScheme(.dark)
+        .onAppear { load() }
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .toolbarBackground(.hidden, for: .navigationBar)
@@ -63,6 +77,72 @@ struct StatisticsView: View {
                         .foregroundStyle(.white)
                 }
             }
+        }
+    }
+
+    // MARK: - Data Loading
+
+    /// 화면 진입 시 리포지토리에서 실제 통계를 읽어 상태에 채운다.
+    /// 새 세션이 저장된 뒤 탭으로 돌아와도 최신 값이 반영되도록 onAppear마다 호출.
+    private func load() {
+        let dates = (try? repository.fetchReadDates()) ?? []
+        readDates = dates
+        flameCount = Self.currentStreak(from: dates, today: Date())
+        earliestMonth = Self.earliestMonth(from: dates)
+
+        monthlyCount = (try? repository.fetchMonthlyBookCount()) ?? 0
+        totalReadCount = (try? repository.fetchTotalBookCount()) ?? 0
+        readBooks = Self.uniqueBooks(from: (try? repository.fetchAllSessions()) ?? [])
+    }
+
+    /// 연속 독서일(스트릭). 오늘부터 거꾸로 "읽은 날"이 끊기지 않은 일수.
+    /// 오늘 아직 안 읽었으면 어제부터 세기 시작(그날이 끝나기 전 스트릭을 잃지 않게).
+    static func currentStreak(from readDates: Set<DateComponents>, today: Date) -> Int {
+        let cal = Calendar(identifier: .gregorian)
+        let readDays: Set<Date> = Set(readDates.compactMap { comps in
+            guard let y = comps.year, let m = comps.month, let d = comps.day else { return nil }
+            return cal.date(from: DateComponents(year: y, month: m, day: d))
+        })
+        guard !readDays.isEmpty else { return 0 }
+
+        let todayStart = cal.startOfDay(for: today)
+        var cursor: Date
+        if readDays.contains(todayStart) {
+            cursor = todayStart
+        } else {
+            // 그레이스: 오늘 미독서면 어제부터. 어제도 비었으면 스트릭 0.
+            guard let yesterday = cal.date(byAdding: .day, value: -1, to: todayStart),
+                  readDays.contains(yesterday) else { return 0 }
+            cursor = yesterday
+        }
+
+        var count = 0
+        while readDays.contains(cursor) {
+            count += 1
+            guard let prev = cal.date(byAdding: .day, value: -1, to: cursor) else { break }
+            cursor = prev
+        }
+        return count
+    }
+
+    /// 가장 처음 책을 읽은 '월'의 1일. 달력 과거 슬라이드 하한으로 쓴다. (기록 없으면 nil)
+    static func earliestMonth(from readDates: Set<DateComponents>) -> Date? {
+        let cal = Calendar(identifier: .gregorian)
+        let monthStarts = readDates.compactMap { comps -> Date? in
+            guard let y = comps.year, let m = comps.month else { return nil }
+            return cal.date(from: DateComponents(year: y, month: m, day: 1))
+        }
+        return monthStarts.min()
+    }
+
+    /// 세션 목록(최근 순)에서 ISBN 기준 중복을 제거한 고유 책 목록.
+    static func uniqueBooks(from sessions: [ReadingSessionProfile]) -> [BookProfileModel] {
+        var seen = Set<String>()
+        return sessions.compactMap { session in
+            let isbn = session.bookProfile.isbn
+            guard !seen.contains(isbn) else { return nil }
+            seen.insert(isbn)
+            return session.bookProfile
         }
     }
 
@@ -143,7 +223,7 @@ struct StatisticsView: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(alignment: .top, spacing: 12) {
-                    ForEach(Array(dummyBooks.enumerated()), id: \.offset) { _, book in
+                    ForEach(Array(readBooks.enumerated()), id: \.offset) { _, book in
                         StatBookThumbnail(coverURL: book.bookCoverImageURL, title: book.bookTitle)
                     }
                 }
@@ -254,14 +334,29 @@ private extension Color {
 #if DEBUG
 private struct PreviewStatsRepository: ReadingSessionRepositoryProtocol {
     func saveSession(_ session: ReadingSessionProfile, bookISBN: String) throws {}
-    func fetchAllSessions() throws -> [ReadingSessionProfile] { [] }
+    func fetchAllSessions() throws -> [ReadingSessionProfile] { ReadingSessionProfile.mockList }
     func findSession(by id: UUID) throws -> ReadingSessionProfile? { nil }
     func deleteSession(by id: UUID) throws {}
     func fetchTodaySessions() throws -> [ReadingSessionProfile] { [] }
     func fetchMonthlyBookCount() throws -> Int { 23 }
     func fetchTotalBookCount() throws -> Int { 18 }
     func fetchTotalSeconds() throws -> Int { 0 }
-    func fetchReadDates() throws -> Set<DateComponents> { [] }
+
+    /// 프리뷰 더미: 오늘 포함 최근 연속 3일(스트릭 확인) + 3개월 전 1건(과거 슬라이드 하한 확인)
+    func fetchReadDates() throws -> Set<DateComponents> {
+        let cal = Calendar(identifier: .gregorian)
+        let today = cal.startOfDay(for: Date())
+        var dates = Set<DateComponents>()
+        for offset in 0...2 {
+            if let d = cal.date(byAdding: .day, value: -offset, to: today) {
+                dates.insert(cal.dateComponents([.year, .month, .day], from: d))
+            }
+        }
+        if let past = cal.date(byAdding: .month, value: -3, to: today) {
+            dates.insert(cal.dateComponents([.year, .month, .day], from: past))
+        }
+        return dates
+    }
 }
 
 #Preview {


### PR DESCRIPTION
<!-- 제목 형식: [타입] #이슈번호 간단한 설명 -->
- Closes #86

## 📝 Summary
통계·달력 화면의 더미·하드코딩을 `ReadingSessionRepository` **실데이터**로 전면 교체하고, 아이 나이·알림 시간 같은 **사용자 설정값을 `UserData`(UserDefaults)에 영속화**하도록 연결했습니다.

스트릭(연속 독서일)은 저장값이 아니라 읽은 날짜에서 **계산**하는 파생 상태로 두고, 설정값은 직접 입력하는 사실이라 **저장**으로 분리했습니다.

### 통계·달력 실데이터 연결
- `StatisticsView` 더미(`flameCount=12`, `monthLabel="2026년 10월"`, `dummyBooks`) 제거 → `onAppear`에서 리포지토리 로드
- **스트릭**: `fetchReadDates()` 기반 계산 (오늘 미독서면 어제부터 세는 그레이스, 빈 날 만나면 끊김)
- 이번 달 횟수 `fetchMonthlyBookCount`(번) · 누적 고유 책 수 `fetchTotalBookCount`(권) · 고유 책 썸네일(세션 ISBN dedup) · 현재 월 라벨 연결
- `MultiSelectCalendarView` 더미(`readDays`, `todayDay`, 고정 `2025-04`) 제거 → `readDates`/`today`/`minMonth` 주입형으로 전환
  - 읽은 날만 하이라이트 · **오늘만 그라데이션**(현재 월일 때만) · 과거 슬라이드·`MonthYearPickerSheet`를 **최초 독서월 이전 불가**로 제한(미래는 이번 달까지)

### 사용자 설정값 UserDefaults 저장
- `UserData`에 `@UserDefault` 3종 추가: `childAge`(기본 6) · `notificationEnabled`(기본 true) · `notificationTime`(기본 21:30)
- `ChildAgeSettingView`, `NotificationTimeSettingView` 더미 `@State` → 진입 시 저장값 로드 / "완료" 시 저장
- `SettingsView` 목록에 저장값 반영 (`@State` + `onAppear` 재로드)

## 🏗 Architecture Decision

### 스트릭: 저장 vs 계산(파생 상태)
- **문제**: 연속 독서일을 어디에 둘 것인가
- **대안 1**: `UserData`/Core Data에 스트릭 값 저장 → 매일 갱신·미독서 시 0 리셋 로직 필요. 앱을 안 켜면 값이 썩고, 갱신 지점이 여러 곳이면 동기화 버그
- **선택**: `fetchReadDates()`로 매번 **계산** → 원본(읽은 날짜)이 단일 진실. 데이터가 소량이라 비용 0, 모델 변경·마이그레이션 없음

### 설정값 저장소: Core Data vs UserDefaults
- **문제**: 아이 나이·알림 시간을 어디에 저장할 것인가
- **대안 1**: `ReadingSession`처럼 Core Data 엔티티 → 단일 설정값에 쿼리·관계는 과함
- **선택**: 기존 `UserData`의 `@UserDefault` 패턴(`lastLightingConfig`와 동일) → 키-값 단일 설정에 정합, 새 패턴 없음

### 설정 목록 갱신: computed vs @State + onAppear
- **문제**: 디테일에서 "완료" 후 `SettingsView`로 돌아오면 값이 즉시 안 바뀜
- **대안 1**: `UserData`를 읽는 computed 프로퍼티 → `NavigationStack` **루트는 path 변경만으로 body 재평가가 안 일어나** 갱신 누락
- **선택**: `@State` + `.onAppear` 재로드 → 루트 복귀 시 `onAppear`가 다시 불려 즉시 갱신 (`StatisticsView`와 동일 패턴)

## 🤝 @YooGyeongMo (데미안) — 온보딩 연결 부탁
**아이 나이 / 알림 시간을 저장할 UserDefaults 칸을 미리 다 만들어 놨습니다.** 온보딩 입력값을 아래에 대입만 하시면 됩니다 — 별도 저장 로직 불필요해요.

```swift
UserData.childAge = 입력한_나이             // Int
UserData.notificationTime = 입력한_시간      // Date (시/분만 의미)
UserData.notificationEnabled = 알림_허용여부  // Bool
```

- 위치: `Core/Storage/UserData.swift` (기존 `lastLightingConfig`와 같은 `@UserDefault` 패턴)
- 읽을 때도 `UserData.childAge`로 바로 접근. 제가 만든 설정 화면도 이미 이 칸을 읽고/써서, 온보딩에서 넣은 값이 설정 화면에도 그대로 보입니다.

## 👀 Review Notes
- 스트릭은 그레이스 규칙: 오늘 안 읽었어도 어제까지 이어졌으면 그 값 유지, 빈 날에서 끊김
- 이번 달 읽어준 횟수 = 세션 수(번) / 총 읽은 책 = unique ISBN(권)
- 달력 미래월은 이번 달까지로 캡 (빈 미래월 의미 없음) — 불필요하면 한 줄로 해제 가능
- 새 stat 쿼리 추가 없이 기존 리포지토리 메서드만 재사용 → 프로토콜·다른 프리뷰 mock 무영향
- `Date`는 UserDefaults plist 네이티브 타입이라 그대로 저장/복원

## 🔮 Future Work
- 실제 로컬 알림 등록(`UNUserNotificationCenter` 권한 + 스케줄링) — 이번엔 저장만
- `ReadingViewModel`의 임시 `childAge = 6` 상수 → `UserData.childAge`로 교체(한 줄)
- 역대 최장 스트릭(최고 기록) 표시 시 별도 저장 검토

## ✅ Test
- [ ] 빌드 확인 (iPhone 17 시뮬레이터 Debug 빌드 성공)
- [ ] 세션 저장 후 통계 탭 — 이번 달 횟수·누적 책 수·썸네일 표시
- [ ] 달력 — 읽은 날 하이라이트 / 오늘 그라데이션 / 최초 독서월 이전 슬라이드 차단
- [ ] 설정 → 나이·시간 변경 → "완료" → 목록 즉시 반영
- [ ] 앱 재실행 후 설정값 유지(영속화) 확인
