### PR TITLE
[Feature] [PO-91] 바코드 스캔 실패 시 책 직접 검색 (제목·저자 검색 + 최근 검색)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/FontLiterals.swift
@@ -141,6 +141,7 @@ extension Font {
 
     // ───── Headline ─────
     static let headlineMedium = pretendard(24, .medium, .title3)
+    static let headlineRegular = pretendard(17, .regular, .headline)   // 표준 Headline 17 (UIFont와 대응)
     static let headlineParagraph = pretendard(24, .medium, .title3)
 
     // ───── Body 1 ─────

--- a/LivingStory-iOS/LivingStory-iOS/Core/Network/ISBN/ISBNLookupService.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Network/ISBN/ISBNLookupService.swift
@@ -46,6 +46,42 @@ final class ISBNLookupService {
             bookDescription: doc.contents
         )
     }
+
+    /// 제목·저자 통합 검색 (바코드 스캔 실패 시 직접 검색용)
+    /// - `target` 파라미터를 생략하면 카카오가 제목/저자/출판사를 통합 검색한다.
+    func searchBooks(query: String) async throws -> [BookProfileModel] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var components = URLComponents(string: "https://dapi.kakao.com/v3/search/book")!
+        components.queryItems = [
+            URLQueryItem(name: "query", value: trimmed),
+            URLQueryItem(name: "size", value: "10")
+        ]
+
+        guard let url = components.url else {
+            throw NetworkError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue(
+            "KakaoAK \(Config.kakaoRESTAPIKey)",
+            forHTTPHeaderField: "Authorization"
+        )
+
+        let response: KakaoBookResponse = try await network.request(request)
+
+        return response.documents.map { doc in
+            BookProfileModel(
+                isbn: preferredISBN(from: doc.isbn),
+                bookCoverImageURL: URL(string: highResImageURL(from: doc.thumbnail)),
+                bookTitle: doc.title,
+                bookAuthor: doc.authors.joined(separator: ", "),
+                bookPublisher: doc.publisher,
+                bookDescription: doc.contents
+            )
+        }
+    }
 }
 
 // MARK: - Private Methods
@@ -58,5 +94,16 @@ private extension ISBNLookupService {
         thumbnailURLString
             .replacingOccurrences(of: "R120x174", with: "R480x0")
             .replacingOccurrences(of: "q85", with: "q100")
+    }
+
+    /// 카카오 검색 결과의 `isbn` 필드는 "ISBN10 ISBN13" 형태의 공백 구분 문자열이다.
+    /// 책의 안정적 식별을 위해 ISBN13(13자리)을 우선 사용하고,
+    /// 없으면 마지막 토큰, 그마저 없으면 원본을 그대로 반환한다.
+    func preferredISBN(from raw: String) -> String {
+        let tokens = raw.split(separator: " ").map(String.init)
+        if let isbn13 = tokens.first(where: { $0.count == 13 }) {
+            return isbn13
+        }
+        return tokens.last ?? raw
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Core/Storage/RecentBookSearchStore.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Storage/RecentBookSearchStore.swift
@@ -1,0 +1,59 @@
+//
+//  RecentBookSearchStore.swift
+//  LivingStory-iOS
+//
+//  Created by Demian Yoo on 7/13/26.
+//
+
+import Foundation
+
+/// 직접(수동) 책 검색에서 선택한 책의 최근 검색 저장소 (UserDefaults + JSON).
+/// - 최대 8개 · ISBN 중복 제거 · 최신순(FIFO)
+/// - 기기당 1유저 전제이므로 UserDefaults로 충분하다.
+/// - 표시·재선택에 필요한 전체 정보를 담기 위해 `BookProfileModel`을 그대로 저장한다.
+enum RecentBookSearchStore {
+
+    static let maxCount = 8
+
+    private static let key = "recentBookSearches"
+    private static let defaults: UserDefaults = .standard
+
+    /// 저장된 최근 검색 목록 (최신순).
+    static func load() -> [BookProfileModel] {
+        guard
+            let data = defaults.data(forKey: key),
+            let books = try? JSONDecoder().decode([BookProfileModel].self, from: data)
+        else {
+            return []
+        }
+        return books
+    }
+
+    /// 최근 검색에 추가. 동일 ISBN은 제거 후 맨 앞으로 올리고, 최대 `maxCount`개만 유지한다.
+    static func add(_ book: BookProfileModel) {
+        var books = load()
+        books.removeAll { $0.isbn == book.isbn }
+        books.insert(book, at: 0)
+        if books.count > maxCount {
+            books = Array(books.prefix(maxCount))
+        }
+        save(books)
+    }
+
+    /// 최근 검색 항목 삭제.
+    static func remove(isbn: String) {
+        var books = load()
+        books.removeAll { $0.isbn == isbn }
+        save(books)
+    }
+
+    /// 최근 검색 전체 삭제.
+    static func clear() {
+        defaults.removeObject(forKey: key)
+    }
+
+    private static func save(_ books: [BookProfileModel]) {
+        guard let data = try? JSONEncoder().encode(books) else { return }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/DirectSearch/BookDirectSearchView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/DirectSearch/BookDirectSearchView.swift
@@ -1,0 +1,276 @@
+//
+//  BookDirectSearchView.swift
+//  LivingStory-iOS
+//
+//  Created by Demian Yoo on 7/13/26.
+//
+//  바코드 스캔 실패 시 "직접 검색" — 제목·저자로 책을 찾아 선택하는 바텀시트.
+//  · 검색어 없음: 최근 검색(가로 썸네일)
+//  · 검색어 있음: 카카오 통합 검색 결과(세로 리스트) → 선택 시 하단 "책 선택" CTA
+
+import SwiftUI
+
+struct BookDirectSearchView: View {
+
+    /// 책 선택 확정 (기존 바코드 성공 플로우로 진입).
+    let onSelect: (BookProfileModel) -> Void
+    /// 닫기 (스캐너 실패 화면으로 복귀).
+    let onClose: () -> Void
+
+    @State private var viewModel = BookDirectSearchViewModel()
+    @FocusState private var isSearchFocused: Bool
+
+    // 디자인 토큰
+    private let labelSecondary = Color(hex: 0xEBEBF5, alpha: 0.7)   // Labels/Secondary
+    private let iconGray = Color(hex: 0x8A8A8A)                     // Labels - Vibrant/Secondary
+    private let fieldFill = Color(hex: 0x787880, alpha: 0.32)       // Fills/Secondary
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.backgroundSecondary.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                header
+                searchField
+                    .padding(.horizontal, 16)
+                    .padding(.top, 4)
+
+                ScrollView {
+                    Group {
+                        if viewModel.isSearching {
+                            resultsSection
+                        } else {
+                            recentSection
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 36)
+                    .padding(.bottom, 120) // CTA 가림 방지
+                }
+            }
+
+            if let book = viewModel.selectedBook {
+                selectButton(for: book)
+            }
+        }
+        .onAppear { viewModel.onAppear() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        ZStack {
+            Text("책 선택")
+                .font(.headlineRegular)
+                .foregroundStyle(Color(hex: 0xF5F5F5))
+
+            HStack {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(iconGray)
+                        .frame(width: 44, height: 44)
+                        .background(fieldFill, in: Circle())
+                }
+                Spacer()
+            }
+            .padding(.leading, 16)
+        }
+        .frame(height: 44)
+    }
+
+    // MARK: - Search Field
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(iconGray)
+
+            TextField(
+                "",
+                text: $viewModel.query,
+                prompt: Text("책 제목 또는 저자 이름").foregroundStyle(iconGray)
+            )
+            .font(.headlineRegular)
+            .foregroundStyle(.white)
+            .tint(Color(hex: 0xBFEE68))
+            .focused($isSearchFocused)
+            .submitLabel(.search)
+            .autocorrectionDisabled()
+            .onChange(of: viewModel.query) { _, _ in viewModel.queryChanged() }
+
+            Image(systemName: "mic.fill")
+                .foregroundStyle(iconGray)
+        }
+        .font(.headlineRegular)
+        .padding(11)
+        .background(fieldFill, in: Capsule())
+    }
+
+    // MARK: - Recent (가로)
+
+    @ViewBuilder
+    private var recentSection: some View {
+        if !viewModel.recentBooks.isEmpty {
+            VStack(alignment: .leading, spacing: 13) {
+                Text("최근 검색")
+                    .font(.labelRegular)
+                    .foregroundStyle(labelSecondary)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 16) {
+                        ForEach(viewModel.recentBooks, id: \.isbn) { book in
+                            RecentBookCell(book: book, secondaryColor: labelSecondary)
+                                .onTapGesture { confirm(book) }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Results (세로)
+
+    @ViewBuilder
+    private var resultsSection: some View {
+        if viewModel.results.isEmpty {
+            if viewModel.isLoading {
+                ProgressView()
+                    .tint(iconGray)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 40)
+            } else {
+                Text("검색 결과가 없어요")
+                    .font(.calloutRegular)
+                    .foregroundStyle(labelSecondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 40)
+            }
+        } else {
+            LazyVStack(spacing: 12) {
+                ForEach(viewModel.results, id: \.isbn) { book in
+                    SearchResultRow(
+                        book: book,
+                        isSelected: viewModel.selectedISBN == book.isbn,
+                        secondaryColor: labelSecondary
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture { viewModel.select(book) }
+                }
+            }
+        }
+    }
+
+    // MARK: - CTA
+
+    private func selectButton(for book: BookProfileModel) -> some View {
+        Button {
+            confirm(book)
+        } label: {
+            Text("책 선택")
+                .font(.buttonMedium)
+                .foregroundStyle(Color(hex: 0xF5F5F5))
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .background(Color.black, in: Capsule())
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 8)
+    }
+
+    // MARK: - Action
+
+    private func confirm(_ book: BookProfileModel) {
+        viewModel.commit(book)
+        onSelect(book)
+    }
+}
+
+// MARK: - Recent Cell (가로 썸네일)
+
+private struct RecentBookCell: View {
+    let book: BookProfileModel
+    let secondaryColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            BookCoverImage(url: book.bookCoverImageURL, cornerRadius: 4)
+                .frame(width: 90, height: 120)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(book.bookTitle)
+                    .font(.calloutMedium)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(book.bookAuthor)
+                    .font(.calloutLight)
+                    .foregroundStyle(secondaryColor)
+                    .lineLimit(1)
+            }
+            .frame(width: 90, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Result Row (세로 리스트)
+
+private struct SearchResultRow: View {
+    let book: BookProfileModel
+    let isSelected: Bool
+    let secondaryColor: Color
+
+    var body: some View {
+        HStack(spacing: 16) {
+            BookCoverImage(url: book.bookCoverImageURL, cornerRadius: 6)
+                .frame(width: 54, height: 72)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(book.bookTitle)
+                    .font(.body2Medium)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(book.bookAuthor)
+                    .font(.calloutRegular)
+                    .foregroundStyle(secondaryColor)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(Color(hex: 0x2C2C2E), in: RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            if isSelected {
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(Color(hex: 0xBFEE68), lineWidth: 1)
+            }
+        }
+    }
+}
+
+// MARK: - Cover Image
+
+private struct BookCoverImage: View {
+    let url: URL?
+    let cornerRadius: CGFloat
+
+    var body: some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            default:
+                Color(hex: 0x2C2C2E)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    BookDirectSearchView(onSelect: { _ in }, onClose: {})
+        .preferredColorScheme(.dark)
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/DirectSearch/BookDirectSearchViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/DirectSearch/BookDirectSearchViewModel.swift
@@ -1,0 +1,88 @@
+//
+//  BookDirectSearchViewModel.swift
+//  LivingStory-iOS
+//
+//  Created by Demian Yoo on 7/13/26.
+//
+
+import Foundation
+import Observation
+
+/// 책 직접 검색 화면 상태.
+/// - 검색어가 비어 있으면 최근 검색(가로) 모드
+/// - 검색어가 있으면 카카오 통합 검색 결과(세로) 모드
+@MainActor
+@Observable
+final class BookDirectSearchViewModel {
+
+    var query = ""
+
+    private(set) var results: [BookProfileModel] = []
+    private(set) var recentBooks: [BookProfileModel] = []
+    private(set) var isLoading = false
+
+    /// 현재 선택된 결과의 ISBN (선택 시 하단 CTA 노출).
+    private(set) var selectedISBN: String?
+
+    private let service = ISBNLookupService.shared
+    private var searchTask: Task<Void, Never>?
+
+    /// 검색 모드 여부 (검색어 존재).
+    var isSearching: Bool {
+        !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// 하단 CTA에 사용할 선택된 책.
+    var selectedBook: BookProfileModel? {
+        guard let selectedISBN else { return nil }
+        return results.first { $0.isbn == selectedISBN }
+    }
+
+    /// 화면 진입 시 최근 검색 로드.
+    func onAppear() {
+        recentBooks = RecentBookSearchStore.load()
+    }
+
+    /// 검색어 변경 → 0.3초 디바운스 후 카카오 검색. 최대 8개만 노출.
+    func queryChanged() {
+        selectedISBN = nil
+        searchTask?.cancel()
+
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            results = []
+            isLoading = false
+            return
+        }
+
+        searchTask = Task { [weak self] in
+            guard let self else { return }
+
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+
+            self.isLoading = true
+            defer { self.isLoading = false }
+
+            do {
+                let books = try await self.service.searchBooks(query: trimmed)
+                guard !Task.isCancelled else { return }
+                self.results = Array(books.prefix(RecentBookSearchStore.maxCount))
+            } catch is CancellationError {
+                return
+            } catch {
+                self.results = []
+            }
+        }
+    }
+
+    /// 검색 결과 항목 선택 (하단 CTA 노출용).
+    func select(_ book: BookProfileModel) {
+        selectedISBN = book.isbn
+    }
+
+    /// 선택 확정 → 최근 검색에 반영.
+    func commit(_ book: BookProfileModel) {
+        RecentBookSearchStore.add(book)
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 // MARK: - Scanner State
 
@@ -33,6 +34,10 @@ final class ScannerViewController: BaseViewController {
     private var detectedISBN: String?
     private var fetchedBook: BookProfileModel?
     private var lookupTask: Task<Void, Never>?
+
+    /// 직접 검색 버튼 위치 제약 — 상태별 토글 (.scanning: 하단 / .failed: "다시 스캔" 위)
+    private var directSearchScanningConstraint: NSLayoutConstraint!
+    private var directSearchFailedConstraint: NSLayoutConstraint!
 
     let scanningDetent = UISheetPresentationController.Detent.custom(identifier: .init("scanning")) { context in
         context.maximumDetentValue * 0.75
@@ -188,10 +193,18 @@ private extension ScannerViewController {
             resultContentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             resultContentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            // 직접 검색 — safe area 바로 위, 중앙
-            directSearchButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8),
+            // 직접 검색 — 중앙 정렬 (세로 위치는 상태별 제약으로 토글)
             directSearchButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
+
+        // .scanning: safe area 바로 위 / .failed: "다시 스캔" 버튼 위
+        directSearchScanningConstraint = directSearchButton.bottomAnchor.constraint(
+            equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8
+        )
+        directSearchFailedConstraint = directSearchButton.bottomAnchor.constraint(
+            equalTo: resultContentView.retryButton.topAnchor, constant: -16
+        )
+        directSearchScanningConstraint.isActive = true
     }
 
     func setupActions() {
@@ -201,7 +214,30 @@ private extension ScannerViewController {
     }
 
     @objc func directSearchTapped() {
-        // TODO: 직접(수동) 책 검색 화면 연결 (검색 플로우 미구현)
+        let searchView = BookDirectSearchView(
+            onSelect: { [weak self] book in
+                guard let self else { return }
+                // 검색 시트를 먼저 닫고, 기존 바코드 성공 플로우를 그대로 재사용
+                self.dismiss(animated: true) {
+                    self.fetchedBook = book
+                    self.state = .success
+                }
+            },
+            onClose: { [weak self] in
+                self?.dismiss(animated: true)
+            }
+        )
+
+        let hostingVC = UIHostingController(rootView: searchView)
+        hostingVC.view.backgroundColor = UIColor(hex: 0x1C1C1E)
+
+        if let sheet = hostingVC.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.preferredCornerRadius = 32
+            sheet.prefersGrabberVisible = true
+        }
+
+        present(hostingVC, animated: true)
     }
 }
 
@@ -274,8 +310,12 @@ private extension ScannerViewController {
         scanningContentView.alpha = state == .scanning ? 1 : 0
         scanningContentView.isHidden = state != .scanning
 
-        // 직접 검색은 스캐닝 상태에서만
-        directSearchButton.isHidden = state != .scanning
+        // 직접 검색은 스캐닝 + 실패 상태에서 노출
+        directSearchButton.isHidden = !(state == .scanning || state == .failed)
+
+        // 위치 제약 토글: 실패 상태에선 "다시 스캔" 위로, 그 외엔 하단
+        directSearchScanningConstraint.isActive = (state != .failed)
+        directSearchFailedConstraint.isActive = (state == .failed)
 
         resultContentView.alpha = state == .scanning ? 0 : 1
         resultContentView.isHidden = state == .scanning


### PR DESCRIPTION
## 개요
바코드 스캔이 실패하거나 인식되지 않을 때, 책을 **제목·저자로 직접 검색**해 선택하는 플로우를 구현했습니다.
검색 → 선택 후에는 바코드 성공과 **동일한 독서 진입 경로**를 재사용해 흐름이 끊기지 않습니다.

Resolves #92

## 작업 내용
### 1. 카카오 통합 검색 + 최근 검색 저장
- `ISBNLookupService.searchBooks(query:)` — `target` 파라미터를 생략해 제목/저자/출판사 통합 검색, 결과의 `isbn` 필드에서 **ISBN13 우선** 파싱(`preferredISBN`)
- `RecentBookSearchStore` — UserDefaults 기반 최근 검색 **8개 FIFO · ISBN 중복 제거**

### 2. 책 직접 검색 화면
- `BookDirectSearchView` / `BookDirectSearchViewModel(@Observable)`
- 검색어 없으면 최근 검색(가로), 있으면 통합 검색 결과(세로) — 디바운스 검색
- 선택 시 하이라이트 + 하단 CTA "책 선택"

### 3. 스캐너 연결
- `ScannerViewController.directSearchTapped()` → 검색 시트 표시, 선택 시 기존 `.success` 플로우 재사용
- 직접 검색 버튼을 `.scanning` + `.failed` 상태에서 노출, 상태별 위치 제약 토글(.scanning: safe area 위 / .failed: "다시 스캔" 버튼 위)

## 커밋
- `[Feat] #PO-91 카카오 제목·저자 통합 검색 API + 최근 검색 저장소`
- `[Feat] #PO-91 책 직접 검색 화면 (제목·저자 검색 + 최근 검색)`
- `[Feat] #PO-91 스캐너에 직접 검색 연결 + 실패 상태 버튼 배치`

## 확인
- [x] 빌드 확인 (iOS Simulator)
- [x] 실기 QA — 검색 → 선택 → 독서 진입, 최근 검색 반영

> 참고: 다크 모드 고정 · Atomic 색/폰트 토큰 준수. Gemini 환경 추천 실패 처리(graceful degradation)는 별도 이슈(PO-96)로 분리했습니다.
