### PR TITLE
[Feature] [PO-92] 듀오링고식 연속 독서일(스트릭) — 세션 파생 계산

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Persistence/StreakCalculator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Persistence/StreakCalculator.swift
@@ -1,0 +1,60 @@
+//
+//  StreakCalculator.swift
+//  LivingStory-iOS
+//
+//  읽은 날짜 집합에서 스트릭(연속일)을 계산하는 순수 로직.
+//  저장소·UI와 무관 → 유닛테스트 가능, 중복 제거(마이·책·결과 화면 공용).
+//
+
+import Foundation
+
+enum StreakCalculator {
+
+    /// 현재 스트릭(연속일). 듀오링고식: 오늘 안 읽었어도 어제 읽었으면 유지(오늘 자정 전까지),
+    /// 어제도 안 읽었으면 0.
+    static func currentStreak(readDays: Set<Date>, today: Date, calendar: Calendar = .current) -> Int {
+        let startToday = calendar.startOfDay(for: today)
+
+        // 카운트 시작점: 오늘 읽었으면 오늘, 아니면 어제(어제 읽었으면 아직 유지)
+        var day: Date
+        if readDays.contains(startToday) {
+            day = startToday
+        } else if let yesterday = calendar.date(byAdding: .day, value: -1, to: startToday),
+                  readDays.contains(yesterday) {
+            day = yesterday
+        } else {
+            return 0
+        }
+
+        var streak = 0
+        while readDays.contains(day) {
+            streak += 1
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: day) else { break }
+            day = prev
+        }
+        return streak
+    }
+
+    /// 역대 최장 스트릭 (통계용)
+    static func longestStreak(readDays: Set<Date>, calendar: Calendar = .current) -> Int {
+        guard !readDays.isEmpty else { return 0 }
+        let sorted = readDays.sorted()
+        var longest = 1
+        var current = 1
+        for i in 1..<sorted.count {
+            if let next = calendar.date(byAdding: .day, value: 1, to: sorted[i - 1]),
+               calendar.isDate(next, inSameDayAs: sorted[i]) {
+                current += 1
+            } else {
+                current = 1
+            }
+            longest = max(longest, current)
+        }
+        return longest
+    }
+
+    /// DateComponents(년/월/일) 집합 → startOfDay Date 집합
+    static func normalizedDays(from components: Set<DateComponents>, calendar: Calendar = .current) -> Set<Date> {
+        Set(components.compactMap { calendar.date(from: $0).map { calendar.startOfDay(for: $0) } })
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Core/Protocols/ReadingSessionRepositoryProtocol.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Protocols/ReadingSessionRepositoryProtocol.swift
@@ -20,4 +20,20 @@ protocol ReadingSessionRepositoryProtocol {
     func fetchTotalBookCount() throws -> Int
     func fetchTotalSeconds() throws -> Int
     func fetchReadDates() throws -> Set<DateComponents>
+
+    // MARK: - 스트릭 (기본구현 제공 — 기존 세션 데이터에서 파생)
+    func fetchCurrentStreak() throws -> Int
+    func hasReadToday() throws -> Bool
+}
+
+// 세션 데이터에서 파생 — 별도 저장 안 함(진실의 원천은 CoreData 세션). 기존 mock도 자동 충족.
+extension ReadingSessionRepositoryProtocol {
+    func fetchCurrentStreak() throws -> Int {
+        let days = StreakCalculator.normalizedDays(from: try fetchReadDates())
+        return StreakCalculator.currentStreak(readDays: days, today: Date())
+    }
+
+    func hasReadToday() throws -> Bool {
+        try !fetchTodaySessions().isEmpty
+    }
 }


### PR DESCRIPTION
## 개요
듀오링고식 **연속 독서일(스트릭)** 을 도입했습니다. 별도 카운터를 저장하지 않고 **CoreData 세션(읽은 날짜)에서 파생**해 계산합니다 → 진실의 원천이 하나(세션)라 화면·알림 어디서 읽어도 값이 일치합니다.

Closes #93

## 작업 내용
### 1. 순수 계산 로직 `StreakCalculator`
- `currentStreak(readDays:today:)` — 오늘/어제 그레이스(오늘 안 읽었어도 어제 읽었으면 자정 전까지 유지) 후 하루씩 역방향 카운트
- `longestStreak(readDays:)` — 역대 최장 연속일
- `normalizedDays(from:)` — `DateComponents` 집합 → `startOfDay` `Date` 집합
- 저장소·UI와 무관한 순수 함수 → **유닛테스트 대상**

### 2. 리포지토리 파생 메서드 (프로토콜 기본구현)
- `fetchCurrentStreak()` — `StreakCalculator` + `fetchReadDates()`로 세션에서 파생
- `hasReadToday()` — 오늘 세션 존재 여부
- 프로토콜 **기본구현**으로 제공 → 기존 mock/구현이 자동 충족, 별도 저장 없음

## 커밋
- `[Feat] #PO-92 스트릭 순수 계산 로직 StreakCalculator`
- `[Feat] #PO-92 리포지토리 스트릭 파생 메서드 (기본구현)`

## 확인
- [x] 빌드 확인 (iOS Simulator, develop 기준 단독 컴파일)
- [ ] 유닛테스트(PO-100에서 그레이스·경계·불연속 케이스)

> 참고: 마이 화면 불꽃 배지 **표시** 연결은 통계 화면 리팩터(PO-93)에서 `fetchCurrentStreak()`를 사용해 처리합니다. 책별 읽은 횟수(`fetchReadCount`)는 PO-94로 분리했습니다.
