### PR TITLE
[Feature] [PO-95] 독서 리마인더 로컬 알림 (매일 정시 + 10분 후) + 온보딩 권한 선행

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/SceneDelegate.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/SceneDelegate.swift
@@ -37,6 +37,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidBecomeActive(_ scene: UIScene) {
         appCoordinator?.activeReadingViewModel?.resume()
+        // 포그라운드 복귀 시 오늘 읽음/스트릭 반영해 알림 재스케줄 (재알림·22시 경고 갱신)
+        Task { await ReadingNotificationScheduler.shared.refreshSchedule() }
     }
 
     func sceneWillResignActive(_ scene: UIScene) {

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -17,6 +17,7 @@ enum StringLiterals {
     enum Home {
         static let menuTitle = "모든 집 리스트"
         static let deviceOff = "꺼짐"
+        static let deviceOn = "켜짐"
 
         // 빈 상태 - 권한 필요
         static let permissionTitle = "홈 앱 권한 허용 필요"
@@ -60,6 +61,11 @@ enum StringLiterals {
         static let adjust = "조정"
         // 조명 조정 시트
         static let lightingAdjustTitle = "조명 조정"
+        // 음악 조정 시트
+        static let musicAdjustTitle = "음악 조정"
+        static let musicFilterAll = "전체"
+        // 환경 미리보기
+        static let envPreviewTitle = "환경 미리보기"
         static let saturation = "채도"
         static let done = "완료"
         static func todayBookCount(_ count: Int) -> String { "오늘 아이에게\n책을 \(count)번 읽어줬어요!" }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/View/PermissionDeniedView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/View/PermissionDeniedView.swift
@@ -16,8 +16,8 @@ struct PermissionDeniedView: View {
             Spacer()
 
             Image(systemName: "house.badge.exclamationmark")
-                .font(.system(size: 52))
-                .foregroundStyle(.white)
+                .font(.system(size: 66))                 // 빈 상태(기기 없음)와 동일 크기
+                .foregroundStyle(.white)                 // 흰색 아이콘 (빈 상태와 통일)
                 .padding(.bottom, 8)
 
             Text(StringLiterals.Home.permissionTitle)
@@ -26,20 +26,13 @@ struct PermissionDeniedView: View {
 
             Text(StringLiterals.Home.permissionSubtitle)
                 .font(.calloutRegular)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(Color(red: 0xEB/255, green: 0xEB/255, blue: 0xF5/255).opacity(0.6))  // 빈 상태와 동일 세컨더리 그레이
                 .multilineTextAlignment(.center)
 
-            Button(action: onOpenSettings) {
-                Text(StringLiterals.Home.permissionButton)
-                    .font(.body2SemiBold)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 28)
-                    .padding(.vertical, 14)
-                    .background {
-                        Capsule().foregroundStyle(.black).glassEffect()   // 검정 글래스
-                    }
+            // 앱 표준 리퀴드 글래스 CTA (clear — 검정이라 안 보이던 문제 해결)
+            PrimaryButtonSwiftUI(title: StringLiterals.Home.permissionButton) {
+                onOpenSettings()
             }
-            .buttonStyle(.plain)
             .padding(.top, 8)
 
             Spacer()

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/View/SetupCompleteView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/View/SetupCompleteView.swift
@@ -8,14 +8,25 @@
 import SwiftUI
 
 struct SetupCompleteView: View {
+    @State private var reveal: CGFloat = 0
+
     var body: some View {
         VStack(spacing: 0) {
             Spacer().frame(height: 230)                  // 체크: 위에서 230
 
-            Image(systemName: "checkmark")
-                .font(.system(size: 88, weight: .bold))
-                .frame(width: 120, height: 120)          // 120 × 120
-                .foregroundStyle(AppGradient.g100.linear) // Gradation 100
+            // 새 Check 에셋 — 왼쪽→오른쪽으로 그려지듯 드러남 (책 완료 화면과 동일 연출)
+            Image("Check")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 120, height: 120)
+                .mask(alignment: .leading) {
+                    GeometryReader { geo in
+                        Rectangle().frame(width: geo.size.width * reveal)
+                    }
+                }
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 0.55)) { reveal = 1 }
+                }
 
             Spacer().frame(height: 20)                   // 체크 ↔ 제목 20
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/ViewModel/OnboardingFlowViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/ViewModel/OnboardingFlowViewModel.swift
@@ -150,15 +150,19 @@ final class OnboardingFlowViewModel {
                 print("[Onboarding] 환경 세팅 저장 실패: \(error.localizedDescription)")
             }
         }
+        // 읽어줄 시간을 단일 소스(UserData)에도 동기화 → 알림 스케줄 기준 통일 (온보딩 CoreData ↔ 설정 UserDefaults)
+        UserData.notificationTime = readingTime
+        UserData.notificationEnabled = true
+
         // 저장이 성공했거나 저장할 게 없을 때만 완료 도장 → 실패 시 다음 진입에서 재세팅 기회 유지.
-        // (완료 화면 전환·메인 이동 자체는 막지 않아 무한 온보딩은 방지)
         if didPersist {
             UserData.hasCompletedInitialSetup = true
         }
-        phase = .completed
 
-        // #33 완료 화면을 잠깐 보여준 뒤 메인으로 전환
+        // 알림 권한을 "먼저" 요청하고(사용자 응답 대기) → 그 다음 완료 화면 애니메이션. (동시 표시 방지)
         Task { [weak self] in
+            await ReadingNotificationScheduler.shared.requestAuthorization()
+            self?.phase = .completed
             try? await Task.sleep(for: .seconds(1.8))
             self?.onCompleted?()
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -13,6 +13,7 @@ struct NotificationTimeSettingView: View {
     // 저장값으로 초기화
     @State private var time: Date = UserData.notificationTime
     @State private var isOn: Bool = UserData.notificationEnabled
+    @State private var permissionDenied = false
 
     var body: some View {
         ZStack {
@@ -49,16 +50,49 @@ struct NotificationTimeSettingView: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 77)
 
+                // 권한 거부 시 안내 — 앱 내 재요청 불가하므로 iOS 설정으로 유도
+                if permissionDenied && isOn {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .foregroundStyle(.yellow60)
+                        Text("알림이 꺼져 있어요. 설정 > 나루 > 알림에서 켜주세요")
+                            .font(.labelRegular)
+                            .foregroundStyle(.white.opacity(0.8))
+                        Spacer()
+                        Button("설정") {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        }
+                        .font(.labelMedium)
+                        .foregroundStyle(.yellow60)
+                    }
+                    .padding(12)
+                    .background(Color(.tertiarySystemBackground), in: RoundedRectangle(cornerRadius: 16))
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+                }
+
                 Spacer()
                 PrimaryButtonSwiftUI(title: StringLiterals.Setting.done) {
                     UserData.notificationTime = time
                     UserData.notificationEnabled = isOn
+                    Task {
+                        if isOn {
+                            _ = await ReadingNotificationScheduler.shared.requestAuthorization()
+                        } else {
+                            await ReadingNotificationScheduler.shared.refreshSchedule()
+                        }
+                    }
                     dismiss()
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 30)
             }
             .ignoresSafeArea(.container, edges: .bottom)
+        }
+        .task {
+            permissionDenied = await ReadingNotificationScheduler.shared.authorizationStatus() == .denied
         }
         .preferredColorScheme(.dark)
         .navigationTitle(StringLiterals.Setting.notificationTitle)

--- a/LivingStory-iOS/LivingStory-iOS/Service/ReadingNotificationScheduler.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/ReadingNotificationScheduler.swift
@@ -1,0 +1,105 @@
+//
+//  ReadingNotificationScheduler.swift
+//  LivingStory-iOS
+//
+//  독서 알림 스케줄러 (로컬 노티).
+//   ① 매일 정시 리마인더  ② 정시 10분 후 재알림  ③ 22시 스트릭 깨짐 경고
+//  시간 소스 = UserData.notificationTime / notificationEnabled (단일 소스).
+//  스트릭/오늘 읽음 여부는 CoreData 세션에서 파생(ReadingSessionRepository).
+//
+
+import Foundation
+import UserNotifications
+
+@MainActor
+final class ReadingNotificationScheduler {
+
+    static let shared = ReadingNotificationScheduler()
+
+    private let center = UNUserNotificationCenter.current()
+    private let sessionRepository: ReadingSessionRepositoryProtocol
+
+    private enum ID {
+        static let reminder = "reading.reminder"        // 매일 정시 (반복)
+        static let followUp = "reading.followUp"         // 정시 +10분 (오늘 1회)
+        static let streakWarning = "reading.streakWarning" // 22시 (오늘 1회)
+    }
+
+    init() {
+        self.sessionRepository = ReadingSessionRepository()
+    }
+
+    /// 테스트 주입용
+    init(sessionRepository: ReadingSessionRepositoryProtocol) {
+        self.sessionRepository = sessionRepository
+    }
+
+    // MARK: - 권한
+
+    /// 권한 요청 (온보딩 시간설정 직후 호출 권장). 반환: 허용 여부.
+    @discardableResult
+    func requestAuthorization() async -> Bool {
+        let granted = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+        await refreshSchedule()
+        return granted
+    }
+
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await center.notificationSettings().authorizationStatus
+    }
+
+    // MARK: - 스케줄
+
+    /// 현재 상태(설정시간·오늘 읽음·스트릭) 기준으로 전체 재스케줄. 앱 포그라운드·설정변경·독서완료 시 호출.
+    func refreshSchedule() async {
+        center.removePendingNotificationRequests(withIdentifiers: [ID.reminder, ID.followUp, ID.streakWarning])
+
+        guard UserData.notificationEnabled else { return }
+        guard await authorizationStatus() == .authorized else { return }
+
+        let cal = Calendar.current
+        let timeComps = cal.dateComponents([.hour, .minute], from: UserData.notificationTime)
+        let hour = timeComps.hour ?? 21
+        let minute = timeComps.minute ?? 30
+
+        // ① 매일 정시 리마인더 (반복)
+        var daily = DateComponents()
+        daily.hour = hour
+        daily.minute = minute
+        add(id: ID.reminder,
+            title: "지금 책 읽을 시간이에요! 📖",
+            body: "오늘의 동화책, 아이와 함께 읽어볼까요?",
+            trigger: UNCalendarNotificationTrigger(dateMatching: daily, repeats: true))
+
+        // ② 정시 10분 후 재알림 (반복 — 앱 안 켜도 매일 발송. 문구가 중립적이라 읽은 날 와도 어색하지 않음)
+        let followTotal = hour * 60 + minute + 10
+        var follow = DateComponents()
+        follow.hour = (followTotal / 60) % 24
+        follow.minute = followTotal % 60
+        add(id: ID.followUp,
+            title: "오늘의 동화책 시간 🌙",
+            body: "아이의 상상력을 키우는 습관 5분이면 충분해요. 함께 읽어볼까요?",
+            trigger: UNCalendarNotificationTrigger(dateMatching: follow, repeats: true))
+        // (22시 스트릭 경고는 제거 — 앱 안 켜면 스트릭 상태를 몰라 신뢰성이 떨어져서 배제)
+    }
+
+    /// 세션 완료 직후 — 오늘의 재알림/경고를 취소하고 재스케줄(오늘 읽음 반영).
+    func onDidRead() async {
+        await refreshSchedule()
+    }
+
+    // MARK: - Private
+
+    private func add(id: String, title: String, body: String, trigger: UNNotificationTrigger) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+        center.add(UNNotificationRequest(identifier: id, content: content, trigger: trigger))
+    }
+
+    private func oneShot(_ date: Date, _ cal: Calendar) -> UNCalendarNotificationTrigger {
+        let comps = cal.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        return UNCalendarNotificationTrigger(dateMatching: comps, repeats: false)
+    }
+}


### PR DESCRIPTION
## 개요
매일 지정 시간에 **독서 리마인더 로컬 알림**을 보냅니다. 온보딩에서 알림 권한을 **먼저(선행)** 받고, 설정 시간 변경·포그라운드 진입 시 재스케줄합니다.

Closes #96

## 작업 내용
### 1. 스케줄러 `ReadingNotificationScheduler` (@MainActor 싱글턴)
- ① 매일 정시 리마인더 ② 정시 **10분 후** 재알림 — 둘 다 반복 트리거(앱 안 켜도 발송)
- 시간 소스 = `UserData.notificationTime` / `notificationEnabled` 단일 소스
- 초기안의 22시 스트릭 경고는 제외(앱 미실행 시 상태를 몰라 신뢰성↓)

### 2. 온보딩 권한 선행 요청
- `OnboardingFlowViewModel.complete()`: `UserData` 저장 후 `await requestAuthorization()` **완료 뒤** 완료 애니메이션(순차 — 팝업과 안 겹침)
- 거부 시 `PermissionDeniedView` / 설정 배너 + 딥링크

### 3. 재스케줄 지점
- `NotificationTimeSettingView` 저장 시 · `SceneDelegate` 포그라운드 진입 시 `refreshSchedule`

## 확인
- [x] 빌드 확인 (iOS Simulator, develop 기준)
- [ ] 실기: 온보딩 권한 팝업 순서, 지정 시간 알림 수신
