### PR TITLE
[Feature] [PO-97] 홈 기기 on/off 옵티미스틱 토글 + 켜짐 글로우 애니메이션

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Model/DeviceModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Model/DeviceModel.swift
@@ -11,10 +11,21 @@ import Foundation
 nonisolated struct DeviceModel: Hashable, Sendable {
     var name: String
     let id: UUID
+    /// HomeKit이 보고한 실제 전원 상태 (authoritative)
     var isOn: Bool
     var deviceType: HomeDeviceType
     var percentage: Int?
-    
+
+    /// 옵티미스틱 목표값 — 사용자가 탭한 순간의 의도. 쓰기 진행 중에만 값이 있고, 확정/롤백되면 nil.
+    /// UI는 항상 이 값을 우선 반영하고(`displayIsOn`), 실제 응답이 오면 확정하거나 되돌린다.
+    var pendingIsOn: Bool?
+
+    /// UI가 그려야 할 전원 상태 — 진행 중이면 목표값, 아니면 실제값.
+    var displayIsOn: Bool { pendingIsOn ?? isOn }
+
+    /// 쓰기 응답을 기다리는 중인지 (셀의 "적용 중" 표시에 사용).
+    var isPending: Bool { pendingIsOn != nil }
+
     // id가 같으면 같은 id
     nonisolated static func == (lhs: DeviceModel, rhs: DeviceModel) -> Bool {
         lhs.id == rhs.id
@@ -28,7 +39,9 @@ nonisolated struct DeviceModel: Hashable, Sendable {
 
 extension DeviceModel {
     var status: String {
-        guard isOn, let percentage else { return StringLiterals.Home.deviceOff }
+        guard displayIsOn else { return StringLiterals.Home.deviceOff }
+        // 켜짐이지만 밝기/볼륨을 아직 모를 때(옵티미스틱 순간)는 "켜짐"으로.
+        guard let percentage else { return StringLiterals.Home.deviceOn }
         return "\(percentage)%"
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeDataSource.swift
@@ -13,6 +13,10 @@ final class HomeDataSource {
 
     private var diffableDataSource: UICollectionViewDiffableDataSource<RoomModel, DeviceModel>!
 
+    /// 화면이 그리는 단일 진실(source of truth). 옵티미스틱 pending 상태까지 여기 담긴다.
+    /// (DeviceModel이 id로만 Hashable이라, 필드가 바뀐 값을 반영하려면 스냅샷을 이 배열로 새로 만들어야 한다.)
+    private var rooms: [RoomModel] = []
+
     // MARK: - Public Methods
 
     func configure(with collectionView: UICollectionView) {
@@ -58,26 +62,94 @@ final class HomeDataSource {
         diffableDataSource.itemIdentifier(for: indexPath)
     }
 
+    /// HomeKit이 보고한 실제 상태로 갱신. 쓰기 진행 중(pending)인 기기는 옵티미스틱 상태를 보존한다.
     func applySnapshot(for home: HomeModel) {
+        let oldById = currentDevicesById()
+        var changed: Set<UUID> = []
+
+        rooms = home.rooms.map { room in
+            var room = room
+            room.devices = room.devices.map { fresh in
+                var device = fresh   // authoritative isOn, pendingIsOn == nil
+                if let old = oldById[fresh.id], let pending = old.pendingIsOn {
+                    // 아직 응답 대기 중: 실제값이 목표에 도달했으면 확정, 아니면 옵티미스틱 유지
+                    device.pendingIsOn = (fresh.isOn == pending) ? nil : pending
+                }
+                if let old = oldById[fresh.id], hasDisplayChange(old, device) {
+                    changed.insert(fresh.id)
+                }
+                return device
+            }
+            return room
+        }
+
+        rebuild(reconfiguring: changed)
+    }
+
+    // MARK: - Optimistic Toggle
+
+    /// 탭 즉시 호출 — 모델에 목표값을 반영해 셀을 곧바로 목표 상태로 그린다.
+    func beginToggle(deviceId: UUID, target: Bool) {
+        mutateDevice(deviceId) { $0.pendingIsOn = target }
+    }
+
+    /// 쓰기 응답 후 호출 — 성공하면 실제값을 목표로 확정, 실패하면 pending을 지워 이전 상태로 롤백.
+    func resolveToggle(deviceId: UUID, success: Bool) {
+        mutateDevice(deviceId) { device in
+            if success, let target = device.pendingIsOn {
+                device.isOn = target
+            }
+            device.pendingIsOn = nil
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension HomeDataSource {
+
+    func currentDevicesById() -> [UUID: DeviceModel] {
+        Dictionary(
+            rooms.flatMap(\.devices).map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    /// 셀이 다시 그려져야 할 만큼 변화가 있는지 (전원 표시/상태문구/pending 스피너).
+    func hasDisplayChange(_ old: DeviceModel, _ new: DeviceModel) -> Bool {
+        old.displayIsOn != new.displayIsOn
+            || old.percentage != new.percentage
+            || old.isPending != new.isPending
+    }
+
+    /// 특정 기기 하나만 바꾸고, 그 셀만 reconfigure.
+    func mutateDevice(_ deviceId: UUID, _ transform: (inout DeviceModel) -> Void) {
+        var didChange = false
+        for roomIndex in rooms.indices {
+            guard let deviceIndex = rooms[roomIndex].devices.firstIndex(where: { $0.id == deviceId })
+            else { continue }
+            let before = rooms[roomIndex].devices[deviceIndex]
+            transform(&rooms[roomIndex].devices[deviceIndex])
+            didChange = hasDisplayChange(before, rooms[roomIndex].devices[deviceIndex])
+            break
+        }
+        if didChange {
+            rebuild(reconfiguring: [deviceId])
+        }
+    }
+
+    /// `rooms`(단일 진실)로 스냅샷을 새로 만들어 적용한다.
+    /// id-only Hashable이라 새 스냅샷을 만들어야 바뀐 필드값이 셀에 전달된다.
+    func rebuild(reconfiguring ids: Set<UUID>) {
         var snapshot = NSDiffableDataSourceSnapshot<RoomModel, DeviceModel>()
-        for room in home.rooms {
+        for room in rooms {
             snapshot.appendSections([room])
             snapshot.appendItems(room.devices, toSection: room)
         }
-
-        // 값이 실제로 바뀐 디바이스만 reconfigure (옵티미스틱 UI 자동 보호)
-        let oldItemsById = Dictionary(
-            diffableDataSource.snapshot().itemIdentifiers.map { ($0.id, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        let itemsToReconfigure = snapshot.itemIdentifiers.filter { newItem in
-            guard let oldItem = oldItemsById[newItem.id] else { return false }
-            return oldItem.isOn != newItem.isOn || oldItem.percentage != newItem.percentage
+        let toReconfigure = snapshot.itemIdentifiers.filter { ids.contains($0.id) }
+        if !toReconfigure.isEmpty {
+            snapshot.reconfigureItems(toReconfigure)
         }
-        if !itemsToReconfigure.isEmpty {
-            snapshot.reconfigureItems(itemsToReconfigure)
-        }
-
         diffableDataSource.apply(snapshot, animatingDifferences: true)
     }
 }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
@@ -13,7 +13,8 @@ final class HomeViewController: BaseViewController {
 
     weak var coordinator: AppCoordinator?
 
-    private let homeKitManager = HomeKitManager()
+    // 실제(HomeKitManager) 또는 목업(MockHomeProvider) — 실행 인자로 결정 (DEBUG)
+    private let homeProvider: HomeDataProviding = HomeProviderFactory.make()
     private let homeDataSource = HomeDataSource()
     private var homes: [HomeModel] = []
     private var currentHome: HomeModel?
@@ -73,11 +74,11 @@ final class HomeViewController: BaseViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        Task { await homeKitManager.refreshAllCharacteristics() }
+        Task { await homeProvider.refreshAllCharacteristics() }
     }
 
     @objc private func handleWillEnterForeground() {
-        Task { await homeKitManager.refreshAllCharacteristics() }
+        Task { await homeProvider.refreshAllCharacteristics() }
     }
 }
 
@@ -194,37 +195,40 @@ extension HomeViewController: UICollectionViewDelegate {
         collectionView.deselectItem(at: indexPath, animated: false)
         guard let device = homeDataSource.device(at: indexPath) else { return }
 
-        // tapped 플래그 — 진행 중이면 재탭 무시
+        // 진행 중이면 재탭 무시 (응답 받을 때까지)
         guard !togglingDeviceIds.contains(device.id) else { return }
         togglingDeviceIds.insert(device.id)
 
+        // 목표값 = 현재 화면에 그려진 상태의 반대 (옵티미스틱 상태 기준)
+        let target = !device.displayIsOn
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
 
-        // 옵티미스틱 UI: 셀 즉시 토글
-        if let cell = collectionView.cellForItem(at: indexPath) as? HomeDeviceCardCell {
-            var newDevice = device
-            newDevice.isOn.toggle()
-            cell.configure(with: newDevice, index: indexPath.item)
-        }
+        // 옵티미스틱: 모델(단일 진실)에 목표값 반영 → 셀은 자동으로 목표 상태 + "적용 중" 표시.
+        // 셀이 화면에 있든 없든(오프스크린) 모델 기준이라 항상 일관되게 반영된다.
+        homeDataSource.beginToggle(deviceId: device.id, target: target)
 
         Task { [weak self] in
-            defer {
-                Task { @MainActor in
-                    self?.togglingDeviceIds.remove(device.id)
-                }
-            }
+            guard let self else { return }
+            var success = false
             do {
-                try await self?.homeKitManager.togglePower(for: device.id)
+                try await self.homeProvider.setPower(target, for: device.id)
+                success = true
             } catch {
                 print("[HomeKit] 전원 토글 실패: \(error.localizedDescription)")
-                // 실패 시 cell 을 실제 상태로 즉시 복원
-                await MainActor.run { [weak self] in
-                    guard let self,
-                          let cell = collectionView.cellForItem(at: indexPath) as? HomeDeviceCardCell,
-                          let actualDevice = self.homeDataSource.device(at: indexPath) else { return }
-                    cell.configure(with: actualDevice, index: indexPath.item)
+            }
+
+            await MainActor.run {
+                // 성공 → 목표값으로 확정, 실패 → 이전 상태로 롤백 (둘 다 pending 해제)
+                self.homeDataSource.resolveToggle(deviceId: device.id, success: success)
+                self.togglingDeviceIds.remove(device.id)
+                if !success {
+                    UINotificationFeedbackGenerator().notificationOccurred(.error)
                 }
-                await self?.homeKitManager.refreshAllCharacteristics()
+            }
+
+            // 실패 시 실제 기기 상태로 재동기화 (타임아웃이었는데 실제로는 켜졌을 수도 있으니)
+            if !success {
+                await self.homeProvider.refreshAllCharacteristics()
             }
         }
     }
@@ -235,7 +239,7 @@ extension HomeViewController: UICollectionViewDelegate {
 private extension HomeViewController {
 
     func bindHomeKit() {
-        homeKitManager.onHomesUpdated = { [weak self] homes in
+        homeProvider.onHomesUpdated = { [weak self] homes in
             guard let self else { return }
             self.homes = homes
 
@@ -253,13 +257,13 @@ private extension HomeViewController {
             }
         }
 
-        homeKitManager.onPermissionDenied = { [weak self] in
+        homeProvider.onPermissionDenied = { [weak self] in
             self?.homes = []
             self?.currentHome = nil
             self?.updateUI(for: .permissionsRequired)
         }
 
-        homeKitManager.checkInitialStatus()
+        homeProvider.checkInitialStatus()
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeDeviceCardCell.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeDeviceCardCell.swift
@@ -25,6 +25,11 @@ final class HomeDeviceCardCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cardView.resetForReuse()   // 재사용 셀에서 켜짐 애니메이션이 잘못 튀지 않도록 초기화
+    }
 }
 
 // MARK: - Public Methods

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeDeviceCardView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/Views/HomeDeviceCardView.swift
@@ -11,11 +11,29 @@ final class HomeDeviceCardView: UIView {
 
     private var homeDeviceType: HomeDeviceType
     private var homeDeviceState: Bool = false
-    private var deviceIndex: Int = 0        // 룸 내 순번 (홀/짝으로 ON 색 결정)
+    /// 직전 표시 상태 — OFF→ON 전환을 감지해 켜짐 애니메이션을 재생한다.
+    /// nil이면 (신규/재사용 셀) 애니메이션 없이 최종 상태만 반영.
+    private var wasOn: Bool?
 
     // 그라데이션 보더 (켜졌을 때만 표시)
     private let borderGradientLayer = CAGradientLayer()
     private let borderMaskLayer = CAShapeLayer()
+
+    // MARK: - 배지/글로우 상수
+
+    private static let badgeSize: CGFloat = 44
+    private static let badgeOffFill = UIColor(hex: 0x545458)   // 꺼짐: 회색 원
+    private static let restGlowOpacity: Float = 0.5            // 켜짐 유지 시 은은한 잔광
+    private static let restGlowRadius: CGFloat = 7
+
+    // 아이콘을 감싸는 원형 배지 — 홈앱처럼 상태 색을 담고, 켜질 때 빛이 번진다.
+    private let iconBadge: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = HomeDeviceCardView.badgeSize / 2
+        view.clipsToBounds = false          // 글로우(그림자)가 배지 밖으로 번지도록
+        view.layer.shadowOffset = .zero
+        return view
+    }()
 
     private let homeIconDeviceImageView: UIImageView = {
         let imageView = UIImageView()
@@ -76,6 +94,9 @@ final class HomeDeviceCardView: UIView {
         borderMaskLayer.lineWidth = lineWidth
         borderMaskLayer.fillColor = UIColor.clear.cgColor
         borderMaskLayer.strokeColor = UIColor.black.cgColor   // 불투명 → 보더만 그라데이션 노출
+
+        // 배지 글로우 경로를 원형으로 고정 (성능 + 정확한 번짐)
+        iconBadge.layer.shadowPath = UIBezierPath(ovalIn: iconBadge.bounds).cgPath
     }
 }
 
@@ -85,12 +106,20 @@ final class HomeDeviceCardView: UIView {
 extension HomeDeviceCardView {
     func configure(with device: DeviceModel, index: Int) {
         self.homeDeviceType = device.deviceType
-        self.homeDeviceState = device.isOn
-        self.deviceIndex = index
+        self.homeDeviceState = device.displayIsOn   // 옵티미스틱 우선 — 탭 즉시 목표 상태로 그림
         deviceNameLabel.text = device.name
         deviceStatusLabel.text = device.status
         updateAppearance()
-        updateAccessibilityLabel()
+        updateAccessibilityLabel(isPending: device.isPending)
+    }
+
+    /// 셀 재사용 직전 호출 — 전환 감지 상태와 진행 중 애니메이션을 초기화해
+    /// 스크롤 중 엉뚱한 셀에서 켜짐 애니메이션이 튀는 것을 막는다.
+    func resetForReuse() {
+        wasOn = nil
+        iconBadge.layer.removeAllAnimations()
+        iconBadge.transform = .identity
+        homeIconDeviceImageView.transform = .identity
     }
 }
 
@@ -109,27 +138,36 @@ private extension HomeDeviceCardView {
         accessibilityHint = "이중 탭하여 전원을 전환합니다"
     }
 
-    func updateAccessibilityLabel() {
+    func updateAccessibilityLabel(isPending: Bool) {
         let deviceTypeName = homeDeviceType == .light ? "조명" : "스피커"
         let stateName = homeDeviceState ? "켜짐" : "꺼짐"
-        accessibilityLabel = "\(deviceNameLabel.text ?? "") \(deviceTypeName), \(stateName)"
+        let pendingSuffix = isPending ? ", 적용 중" : ""
+        accessibilityLabel = "\(deviceNameLabel.text ?? "") \(deviceTypeName), \(stateName)\(pendingSuffix)"
     }
 
     func setupHierarchy() {
-        addSubview(homeIconDeviceImageView)
+        addSubview(iconBadge)
+        iconBadge.addSubview(homeIconDeviceImageView)
         addSubview(labelStackView)
         labelStackView.addArrangedSubview(deviceNameLabel)
         labelStackView.addArrangedSubview(deviceStatusLabel)
     }
 
     func setupLayout() {
+        iconBadge.translatesAutoresizingMaskIntoConstraints = false
         homeIconDeviceImageView.translatesAutoresizingMaskIntoConstraints = false
         labelStackView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            // 아이콘 (상·좌측 14, 박스 없이 심볼만)
-            homeIconDeviceImageView.topAnchor.constraint(equalTo: topAnchor, constant: 18),
-            homeIconDeviceImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            // 원형 배지 (상·좌측)
+            iconBadge.topAnchor.constraint(equalTo: topAnchor, constant: 14),
+            iconBadge.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            iconBadge.widthAnchor.constraint(equalToConstant: Self.badgeSize),
+            iconBadge.heightAnchor.constraint(equalToConstant: Self.badgeSize),
+
+            // 아이콘은 배지 중앙
+            homeIconDeviceImageView.centerXAnchor.constraint(equalTo: iconBadge.centerXAnchor),
+            homeIconDeviceImageView.centerYAnchor.constraint(equalTo: iconBadge.centerYAnchor),
 
             // 라벨 스택뷰
             labelStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
@@ -138,38 +176,99 @@ private extension HomeDeviceCardView {
         ])
     }
 
+    // MARK: - Appearance
+
     func updateAppearance() {
+        let theme = homeDeviceType.theme
         homeIconDeviceImageView.image = homeDeviceType.homeIcon
 
-        if homeDeviceState {
-            activateStyle()
+        let isOn = homeDeviceState
+        // 이미 화면에 있고(=window) 상태가 실제로 바뀐 경우에만 켜짐/꺼짐 전환 애니메이션.
+        let animated = (wasOn != nil && wasOn != isOn && window != nil)
+
+        // 카드 배경 · 보더 · 라벨
+        if isOn {
+            backgroundColor = theme.cardOn
+            applyBorderGradient(theme.border)
+            deviceNameLabel.textColor = .white
+            deviceStatusLabel.textColor = theme.statusOn
         } else {
-            inactivateStyle()
+            backgroundColor = UIColor(hex: 0x3A3A3C)
+            borderGradientLayer.isHidden = true
+            deviceNameLabel.textColor = UIColor(hex: 0xEBEBF5).withAlphaComponent(0.7)
+            deviceStatusLabel.textColor = UIColor(hex: 0xEBEBF5).withAlphaComponent(0.35)
+        }
+
+        renderBadge(isOn: isOn, theme: theme, animated: animated)
+        wasOn = isOn
+    }
+
+    /// 배지(원 + 아이콘)를 상태에 맞게 렌더. 켜짐 전환이면 "확 켜지는" 글로우 애니메이션.
+    func renderBadge(isOn: Bool, theme: DeviceCardTheme, animated: Bool) {
+        if isOn {
+            iconBadge.backgroundColor = theme.badgeOnFill
+            homeIconDeviceImageView.tintColor = .white     // 켜짐: 흰 아이콘
+            iconBadge.layer.shadowColor = theme.badgeOnFill.cgColor
+
+            if animated {
+                playTurnOn()
+            } else {
+                iconBadge.transform = .identity
+                homeIconDeviceImageView.transform = .identity
+                iconBadge.layer.shadowOpacity = Self.restGlowOpacity   // 잔광 유지
+                iconBadge.layer.shadowRadius = Self.restGlowRadius
+            }
+        } else {
+            // 꺼짐: 회색 원 + 컴포넌트 고유색 아이콘(죽은 회색 아님)
+            let applyOff = {
+                self.iconBadge.backgroundColor = Self.badgeOffFill
+                self.homeIconDeviceImageView.tintColor = theme.accent
+            }
+            if animated {
+                UIView.transition(with: iconBadge, duration: 0.22, options: .transitionCrossDissolve, animations: applyOff)
+            } else {
+                applyOff()
+            }
+            iconBadge.transform = .identity
+            homeIconDeviceImageView.transform = .identity
+            iconBadge.layer.shadowOpacity = 0
         }
     }
 
-    func activateStyle() {
-        let isOddPosition = deviceIndex % 2 == 0   // 룸 내 1·3·5번째 → 노랑
-        if isOddPosition {
-            backgroundColor = UIColor(named: "yellow900")
-            applyBorderGradient(AppGradient.g10)
-            homeIconDeviceImageView.tintColor = UIColor(named: "yellow80")
-            deviceStatusLabel.textColor = UIColor(named: "yellow60")
-        } else {
-            backgroundColor = UIColor(named: "blue800")
-            applyBorderGradient(AppGradient.g20)
-            homeIconDeviceImageView.tintColor = UIColor(named: "blue0")
-            deviceStatusLabel.textColor = UIColor(named: "blue0")
+    /// 전구가 확 켜지는 표현: ① 스프링 스케일 팝 ② 빛무리(글로우)가 확 번졌다가 잔광으로 가라앉음.
+    func playTurnOn() {
+        // ① 스케일 팝 — 배지는 살짝, 아이콘은 크게 튕겨 "탁" 켜지는 느낌
+        iconBadge.transform = CGAffineTransform(scaleX: 0.86, y: 0.86)
+        homeIconDeviceImageView.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        UIView.animate(
+            withDuration: 0.55,
+            delay: 0,
+            usingSpringWithDamping: 0.5,
+            initialSpringVelocity: 0.7,
+            options: [.allowUserInteraction]
+        ) {
+            self.iconBadge.transform = .identity
+            self.homeIconDeviceImageView.transform = .identity
         }
-        deviceNameLabel.textColor = .white          // Labels Primary
-    }
 
-    func inactivateStyle() {
-        backgroundColor = UIColor(hex: 0x3A3A3C)
-        borderGradientLayer.isHidden = true
-        homeIconDeviceImageView.tintColor = UIColor(hex: 0xEBEBF5).withAlphaComponent(0.3)
-        deviceNameLabel.textColor = UIColor(hex: 0xEBEBF5).withAlphaComponent(0.7)
-        deviceStatusLabel.textColor = UIColor(hex: 0xEBEBF5).withAlphaComponent(0.3)
+        // ② 글로우 블룸 — 0 → 강하게 → 은은한 잔광
+        let glowOpacity = CAKeyframeAnimation(keyPath: "shadowOpacity")
+        glowOpacity.values = [0.0, 1.0, Self.restGlowOpacity]
+        glowOpacity.keyTimes = [0.0, 0.4, 1.0]
+        glowOpacity.duration = 0.6
+        glowOpacity.timingFunction = CAMediaTimingFunction(name: .easeOut)
+
+        let glowRadius = CAKeyframeAnimation(keyPath: "shadowRadius")
+        glowRadius.values = [2.0, 16.0, Self.restGlowRadius]
+        glowRadius.keyTimes = [0.0, 0.4, 1.0]
+        glowRadius.duration = 0.6
+        glowRadius.timingFunction = CAMediaTimingFunction(name: .easeOut)
+
+        // 애니메이션 종료 후 머무를 최종값 먼저 세팅 (튐 방지)
+        iconBadge.layer.shadowOpacity = Self.restGlowOpacity
+        iconBadge.layer.shadowRadius = Self.restGlowRadius
+        iconBadge.layer.add(glowOpacity, forKey: "turnOnGlowOpacity")
+        iconBadge.layer.add(glowRadius, forKey: "turnOnGlowRadius")
     }
 
     func applyBorderGradient(_ token: GradientToken) {
@@ -179,6 +278,40 @@ private extension HomeDeviceCardView {
         borderGradientLayer.startPoint = source.startPoint
         borderGradientLayer.endPoint = source.endPoint
         borderGradientLayer.isHidden = false
+    }
+}
+
+// MARK: - Device Theme (컴포넌트 타입별 색상)
+
+/// 기기 타입마다 고유한 색 테마. 위치(홀/짝)가 아니라 "무슨 기기인가"로 색이 정해진다.
+fileprivate struct DeviceCardTheme {
+    let cardOn: UIColor          // 켜짐 카드 배경
+    let border: GradientToken    // 켜짐 보더 그라데이션
+    let badgeOnFill: UIColor     // 켜짐 배지 원(+글로우 색)
+    let accent: UIColor          // 꺼짐 아이콘 색 (고유색 유지)
+    let statusOn: UIColor        // 켜짐 상태 텍스트 색
+}
+
+fileprivate extension HomeDeviceType {
+    var theme: DeviceCardTheme {
+        switch self {
+        case .light:
+            return DeviceCardTheme(
+                cardOn: UIColor(named: "yellow900") ?? UIColor(hex: 0x524922),
+                border: AppGradient.g10,
+                badgeOnFill: UIColor(named: "yellow0") ?? UIColor(hex: 0xFBC928),
+                accent: UIColor(named: "yellow80") ?? UIColor(hex: 0xFFE451),
+                statusOn: UIColor(named: "yellow60") ?? UIColor(hex: 0xFCDF42)
+            )
+        case .speaker:
+            return DeviceCardTheme(
+                cardOn: UIColor(named: "blue800") ?? UIColor(hex: 0x314760),
+                border: AppGradient.g20,
+                badgeOnFill: UIColor(named: "blue60") ?? UIColor(hex: 0x6BB2FB),
+                accent: UIColor(named: "blue0") ?? UIColor(hex: 0x87C2FF),
+                statusOn: UIColor(named: "blue0") ?? UIColor(hex: 0x87C2FF)
+            )
+        }
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeDataProviding.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeDataProviding.swift
@@ -1,0 +1,48 @@
+//
+//  HomeDataProviding.swift
+//  LivingStory-iOS
+//
+//  HomeViewController가 의존하는 "집/기기 데이터 소스" 추상화.
+//  실제(HomeKitManager)와 목업(MockHomeProvider)을 갈아끼워 UI를 테스트한다.
+//
+
+import Foundation
+
+protocol HomeDataProviding: AnyObject {
+    /// 집 목록 갱신 콜백 (항상 메인에서 호출)
+    var onHomesUpdated: (@MainActor ([HomeModel]) -> Void)? { get set }
+    /// 권한 거부 콜백 (항상 메인에서 호출)
+    var onPermissionDenied: (@MainActor () -> Void)? { get set }
+
+    /// 초기 상태 확인 → 준비되면 onHomesUpdated/onPermissionDenied 호출
+    func checkInitialStatus()
+    /// 기기 전원을 목표값으로 설정 (실패/타임아웃 시 throw → 호출부 롤백)
+    func setPower(_ isOn: Bool, for deviceId: UUID, timeout: TimeInterval) async throws
+    /// 모든 특성 최신값 재동기화
+    func refreshAllCharacteristics() async
+}
+
+extension HomeDataProviding {
+    /// 기본 타임아웃(5초) 편의 오버로드
+    func setPower(_ isOn: Bool, for deviceId: UUID) async throws {
+        try await setPower(isOn, for: deviceId, timeout: 5)
+    }
+}
+
+// MARK: - Factory
+
+enum HomeProviderFactory {
+    /// 실행 인자/환경변수로 목업 데이터 주입 (DEBUG 빌드에서만).
+    ///   • Xcode Scheme ▸ Run ▸ Arguments 에 `-UITestMockHome` 추가, 또는
+    ///   • 환경변수 `MOCK_HOME=1`, 또는 XCUITest `app.launchArguments = ["-UITestMockHome"]`
+    static func make() -> HomeDataProviding {
+        #if DEBUG
+        let args = ProcessInfo.processInfo.arguments
+        let env = ProcessInfo.processInfo.environment
+        if args.contains("-UITestMockHome") || env["MOCK_HOME"] == "1" {
+            return MockHomeProvider()
+        }
+        #endif
+        return HomeKitManager()
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -7,7 +7,19 @@
 
 import HomeKit
 
-final class HomeKitManager: NSObject {
+enum HomeKitError: LocalizedError {
+    case characteristicNotFound
+    case timeout
+
+    var errorDescription: String? {
+        switch self {
+        case .characteristicNotFound: return "기기의 전원 특성을 찾을 수 없습니다."
+        case .timeout: return "기기 응답 시간이 초과되었습니다."
+        }
+    }
+}
+
+final class HomeKitManager: NSObject, HomeDataProviding {
 
     // MARK: - Properties
 
@@ -35,11 +47,22 @@ final class HomeKitManager: NSObject {
         }
     }
 
-    /// 기기의 전원 상태를 토글 (on ↔ off)
-    func togglePower(for deviceId: UUID) async throws {
-        guard let characteristic = findPowerCharacteristic(for: deviceId) else { return }
-        let currentValue = (characteristic.value as? Bool) ?? false
-        try await characteristic.writeValue(!currentValue)
+    /// 기기 전원을 명시한 목표값으로 설정. 특성을 못 찾거나 timeout 초과 시 throw → 호출부가 UI를 롤백.
+    /// 목표값을 인자로 받아 "탭한 순간의 의도"와 실제 write를 일치시킨다(현재값 재읽기에 의존하지 않음).
+    func setPower(_ isOn: Bool, for deviceId: UUID, timeout: TimeInterval = 5) async throws {
+        guard let characteristic = findPowerCharacteristic(for: deviceId) else {
+            throw HomeKitError.characteristicNotFound
+        }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await characteristic.writeValue(isOn) }
+            group.addTask {
+                try await Task.sleep(for: .seconds(timeout))
+                throw HomeKitError.timeout
+            }
+            // 먼저 끝나는 쪽(성공 또는 타임아웃)을 취해 결과 확정, 나머지는 취소.
+            try await group.next()
+            group.cancelAll()
+        }
     }
 
     /// 모든 구독 대상 특성의 최신 값을 HomeKit에서 읽어옴 (포그라운드 복귀 시 호출)

--- a/LivingStory-iOS/LivingStory-iOS/Testing/MockHomeData.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Testing/MockHomeData.swift
@@ -1,0 +1,58 @@
+//
+//  MockHomeData.swift
+//  LivingStory-iOS
+//
+//  UI 테스트/QA용 가짜 홈 데이터. DEBUG 빌드에서만 컴파일된다.
+//  집 2개: "우리집"(거실·안방 기기) + "사무실"(기기 없음 → 빈 상태 UI 확인).
+//
+
+#if DEBUG
+import Foundation
+
+enum MockHomeData {
+
+    static func makeHomes() -> [HomeModel] {
+        // 우리집 — 거실 3, 안방 3
+        let livingRoom = RoomModel(
+            name: "거실",
+            id: id("A1"),
+            devices: [
+                DeviceModel(name: "거실 조명 1", id: id("D1"), isOn: true,  deviceType: .light,   percentage: 80),
+                DeviceModel(name: "거실 조명 2", id: id("D2"), isOn: false, deviceType: .light,   percentage: 60),
+                DeviceModel(name: "마샬 스피커", id: id("D3"), isOn: true,  deviceType: .speaker, percentage: 45)
+            ]
+        )
+        let bedroom = RoomModel(
+            name: "안방",
+            id: id("A2"),
+            devices: [
+                DeviceModel(name: "나노리프 1",   id: id("D4"), isOn: false, deviceType: .light,   percentage: 50),
+                DeviceModel(name: "아카라 조명 1", id: id("D5"), isOn: true,  deviceType: .light,   percentage: 100),
+                DeviceModel(name: "마샬 스피커 2", id: id("D6"), isOn: false, deviceType: .speaker, percentage: 30)
+            ]
+        )
+        let myHome = HomeModel(
+            id: id("E1"),
+            name: "우리집",
+            state: .normal,
+            rooms: [livingRoom, bedroom]
+        )
+
+        // 사무실 — 기기 없음 (빈 상태 UI)
+        let office = HomeModel(
+            id: id("E2"),
+            name: "사무실",
+            state: .noDevices,
+            rooms: []
+        )
+
+        return [myHome, office]
+    }
+
+    /// 테스트 재현성을 위한 고정 UUID
+    private static func id(_ suffix: String) -> UUID {
+        let padded = suffix.padding(toLength: 12, withPad: "0", startingAt: 0)
+        return UUID(uuidString: "00000000-0000-0000-0000-\(padded)") ?? UUID()
+    }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Testing/MockHomeProvider.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Testing/MockHomeProvider.swift
@@ -1,0 +1,49 @@
+//
+//  MockHomeProvider.swift
+//  LivingStory-iOS
+//
+//  HomeKit 없이 UI를 구동하는 가짜 프로바이더 (DEBUG 전용).
+//  실제 기기 왕복을 흉내내는 지연을 넣어 옵티미스틱 UI·켜짐 애니메이션을 검증할 수 있다.
+//
+
+#if DEBUG
+import Foundation
+
+final class MockHomeProvider: HomeDataProviding, @unchecked Sendable {
+
+    var onHomesUpdated: (@MainActor ([HomeModel]) -> Void)?
+    var onPermissionDenied: (@MainActor () -> Void)?
+
+    private let lock = NSLock()
+    private var homes = MockHomeData.makeHomes()
+
+    func checkInitialStatus() {
+        emit()
+    }
+
+    func setPower(_ isOn: Bool, for deviceId: UUID, timeout: TimeInterval) async throws {
+        // 실제 기기 왕복 흉내 (옵티미스틱 UI/글로우 애니메이션 확인용)
+        try? await Task.sleep(for: .milliseconds(300))
+        // async 안에서는 lock()/unlock() 직접 호출 금지 → 스코프 락 사용
+        lock.withLock {
+            outer: for h in homes.indices {
+                for r in homes[h].rooms.indices {
+                    if let i = homes[h].rooms[r].devices.firstIndex(where: { $0.id == deviceId }) {
+                        homes[h].rooms[r].devices[i].isOn = isOn
+                        break outer
+                    }
+                }
+            }
+        }
+    }
+
+    func refreshAllCharacteristics() async {
+        emit()
+    }
+
+    private func emit() {
+        let snapshot = lock.withLock { homes }
+        Task { @MainActor in onHomesUpdated?(snapshot) }
+    }
+}
+#endif


### PR DESCRIPTION
## 개요
홈 화면 기기 카드에서 **탭 즉시 on/off**가 반영되는 옵티미스틱 토글 + 켜짐 순간 글로우 애니메이션을 구현했습니다. 네트워크(HomeKit) 왕복을 기다리지 않고 즉시 UI에 반영하고, 실패/타임아웃 시 이전 상태로 롤백합니다.

Closes #98

## 작업 내용
### 1. 데이터 소스 추상화 `HomeDataProviding`
- `setPower(_:for:timeout:)` / `refreshAllCharacteristics()` 프로토콜
- `HomeProviderFactory.make()`: 실제 `HomeKitManager` / (DEBUG·`-UITestMockHome`) `MockHomeProvider` 분기

### 2. 옵티미스틱 반영
- 탭 → 모델 즉시 토글(single source of truth) → 셀 갱신, 성공 확정 / 실패·타임아웃 롤백 — `HomeViewController` / `HomeDataSource` / `HomeDeviceCardCell` / `HomeDeviceCardView`
- 켜짐 시 카드 글로우 애니메이션 — `DeviceModel` / `HomeKitManager`

### 3. UI 테스트용 목 제공자
- `MockHomeData`(집 2개 + 빈 집) / `MockHomeProvider` — 팩토리의 테스트 심(seam)이라 함께 포함

## 확인
- [x] 빌드 확인 (iOS Simulator, develop 기준)
- [ ] 실기/목: 탭 즉시 반영·실패 롤백·글로우
