### PR TITLE
[Chore] [PO-101] QA 목 실행 인자 + 결과 화면 스트릭 연동 마무리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ iOSInjectionProject/
 
 # Development tools
 .claude/
+CLAUDE.md
 
 # Secrets
 **/Secrets.swift

--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -74,6 +74,12 @@
             ReferencedContainer = "container:LivingStory-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-UITestMockHome"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ResultView.swift
@@ -14,8 +14,10 @@ struct ResultView: View {
     let coordinator: AppCoordinator
     let repository: ReadingSessionRepositoryProtocol
 
-    // TODO: 연속일(streak) 데이터 연동 — 현재 더미 고정값
-    private let flameCount = 12
+    // 연속일(streak) — CoreData 세션에서 파생 (StreakCalculator)
+    private var flameCount: Int {
+        (try? repository.fetchCurrentStreak()) ?? 0
+    }
 
     private var todaySessions: [ReadingSessionProfile] {
         (try? repository.fetchTodaySessions()) ?? []
@@ -26,15 +28,15 @@ struct ResultView: View {
             Color.black.ignoresSafeArea()
 
             VStack(spacing: 0) {
-                Spacer()
+                Spacer().frame(height: 65)    // 헤더 → 스트릭
 
                 flameRow
 
-                Spacer().frame(height: 52)
+                Spacer().frame(height: 55)    // 스트릭 → 애니메이션 스택
 
                 BookStackAnimationView()
 
-                Spacer().frame(height: 30)
+                Spacer().frame(height: 36)    // 스택 → "오늘 N권" 텍스트
 
                 Text(StringLiterals.Reading.todayReadBooks(todaySessions.count))
                     .font(.headlineMedium)
@@ -43,7 +45,7 @@ struct ResultView: View {
                     .lineSpacing(6)
                     .tracking(0.5)
 
-                Spacer().frame(height: 52)
+                Spacer().frame(height: 57)    // 텍스트 → 책 데이터
 
                 bookThumbnails
 


### PR DESCRIPTION
## 개요
QA/테스트 인프라 마무리 + 결과 화면 스트릭 연동 정리입니다.

Closes #102

## 작업 내용
- **스킴 실행 인자** `-UITestMockHome` 추가 → `HomeProviderFactory`가 목 홈 제공자 주입(#PO-97과 연동, DEBUG 전용)
- `.gitignore`: `CLAUDE.md` 무시 추가
- `ResultView`: 결과 화면 연속일도 더미(12) 제거 → 공용 `fetchCurrentStreak`(StreakCalculator) 연동 + 간격 정리

## 확인
- [x] 빌드 확인 (iOS Simulator, develop 기준)

> 참고: 이슈 #102에 있던 스트릭 시드(StreakDataSeeder)·추가 실패 시나리오 인자는 이번 범위에 미포함(후속). 목 홈 데이터/제공자는 팩토리 의존성이라 #PO-97에 포함했습니다.
