### PR TITLE
[Test] [PO-100] 유닛 + 네트워크 스텁 테스트 (스트릭·리포지토리·카카오 디코딩)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOSTests/KakaoBookResponseDecodingTests.swift
+++ b/LivingStory-iOS/LivingStory-iOSTests/KakaoBookResponseDecodingTests.swift
@@ -1,0 +1,93 @@
+//
+//  KakaoBookResponseDecodingTests.swift
+//  LivingStory-iOSTests
+//
+//  네트워크 스텁(URLProtocol)으로 카카오 응답을 주입해 DTO 디코딩 계약을 검증한다.
+//  실서버·네트워크에 의존하지 않고 오프라인·결정적으로 돈다.
+//  (ISBNLookupService end-to-end 스텁은 NetworkService의 URLSession 주입이 선행되어야 함 — 후속)
+//
+
+import XCTest
+@testable import LivingStory_iOS
+
+/// 지정한 데이터/상태코드를 즉시 돌려주는 테스트용 URLProtocol.
+final class URLProtocolStub: URLProtocol {
+    nonisolated(unsafe) static var stubData: Data?
+    nonisolated(unsafe) static var stubStatus: Int = 200
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://stub.local")!,
+            statusCode: Self.stubStatus,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data = Self.stubData {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+final class KakaoBookResponseDecodingTests: XCTestCase {
+
+    private func stubbedSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: config)
+    }
+
+    override func tearDown() {
+        URLProtocolStub.stubData = nil
+        URLProtocolStub.stubStatus = 200
+        super.tearDown()
+    }
+
+    func test_정상응답_디코딩_및_snakeCase매핑() async throws {
+        let json = """
+        {
+          "documents": [
+            {
+              "title": "별 헤는 밤",
+              "contents": "밤하늘 이야기",
+              "thumbnail": "https://search1.kakaocdn.net/.../R120x174.jpg?q85",
+              "authors": ["윤동주"],
+              "isbn": "8912345 9788912345678",
+              "publisher": "펭귄"
+            }
+          ],
+          "meta": { "total_count": 1 }
+        }
+        """.data(using: .utf8)!
+        URLProtocolStub.stubData = json
+
+        let url = URL(string: "https://dapi.kakao.com/v3/search/book?query=별")!
+        let (data, _) = try await stubbedSession().data(for: URLRequest(url: url))
+        let decoded = try JSONDecoder().decode(KakaoBookResponse.self, from: data)
+
+        XCTAssertEqual(decoded.documents.count, 1)
+        XCTAssertEqual(decoded.meta.totalCount, 1)                       // total_count → totalCount
+        let doc = try XCTUnwrap(decoded.documents.first)
+        XCTAssertEqual(doc.title, "별 헤는 밤")
+        XCTAssertEqual(doc.authors.first, "윤동주")
+        XCTAssertTrue(doc.isbn.contains("9788912345678"))               // ISBN13 포함(공백 구분)
+    }
+
+    func test_빈결과_디코딩() async throws {
+        let json = #"{ "documents": [], "meta": { "total_count": 0 } }"#.data(using: .utf8)!
+        URLProtocolStub.stubData = json
+
+        let url = URL(string: "https://dapi.kakao.com/v3/search/book?query=없는책")!
+        let (data, _) = try await stubbedSession().data(for: URLRequest(url: url))
+        let decoded = try JSONDecoder().decode(KakaoBookResponse.self, from: data)
+
+        XCTAssertTrue(decoded.documents.isEmpty)
+        XCTAssertEqual(decoded.meta.totalCount, 0)
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOSTests/ReadingSessionRepositoryTests.swift
+++ b/LivingStory-iOS/LivingStory-iOSTests/ReadingSessionRepositoryTests.swift
@@ -1,0 +1,112 @@
+//
+//  ReadingSessionRepositoryTests.swift
+//  LivingStory-iOSTests
+//
+//  ReadingSessionRepository 통합 테스트 — 인메모리 CoreData(NaruModel) 스택을 매 테스트마다 새로 띄워 격리.
+//  세션에서 파생되는 통계(읽은 날짜/월간/스트릭/시간)가 실제 저장과 일치하는지 검증한다.
+//
+
+import XCTest
+import CoreData
+@testable import LivingStory_iOS
+
+@MainActor
+final class ReadingSessionRepositoryTests: XCTestCase {
+
+    private var repo: ReadingSessionRepository!
+
+    override func setUp() {
+        super.setUp()
+        // /dev/null 스토어 = 디스크에 안 쓰는 인메모리, 테스트 간 상태 공유 없음
+        let container = NSPersistentContainer(name: "NaruModel")
+        container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        let exp = expectation(description: "load store")
+        container.loadPersistentStores { _, error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+        repo = ReadingSessionRepository(context: container.viewContext)
+    }
+
+    override func tearDown() {
+        repo = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession(isbn: String, start: Date) -> ReadingSessionProfile {
+        ReadingSessionProfile(
+            id: UUID(),
+            startTime: start,
+            endTime: start.addingTimeInterval(300),
+            durationSeconds: 300,
+            bookProfile: BookProfileModel(
+                isbn: isbn,
+                bookCoverImageURL: nil,
+                bookTitle: "테스트 책",
+                bookAuthor: "저자",
+                bookPublisher: "출판사",
+                bookDescription: "설명"
+            ),
+            musicCategory: nil,
+            lighting: .default,
+            conversations: [],
+            memo: nil,
+            createdAt: start
+        )
+    }
+
+    // MARK: - Tests
+
+    func test_저장한세션의_읽은날짜가_정확히집계된다() throws {
+        let cal = Calendar(identifier: .gregorian)
+        let d1 = cal.date(from: DateComponents(year: 2026, month: 7, day: 10))!
+        let d2 = cal.date(from: DateComponents(year: 2026, month: 7, day: 11))!
+        try repo.saveSession(makeSession(isbn: "111", start: d1), bookISBN: "111")
+        try repo.saveSession(makeSession(isbn: "111", start: d2), bookISBN: "111")
+
+        XCTAssertEqual(try repo.fetchReadDates().count, 2)
+    }
+
+    func test_같은날_두세션이면_읽은날짜는_1개로_중복제거() throws {
+        let cal = Calendar(identifier: .gregorian)
+        let morning = cal.date(from: DateComponents(year: 2026, month: 7, day: 10, hour: 9))!
+        let night = cal.date(from: DateComponents(year: 2026, month: 7, day: 10, hour: 21))!
+        try repo.saveSession(makeSession(isbn: "111", start: morning), bookISBN: "111")
+        try repo.saveSession(makeSession(isbn: "222", start: night), bookISBN: "222")
+
+        XCTAssertEqual(try repo.fetchReadDates().count, 1)
+    }
+
+    func test_이번달세션수_집계() throws {
+        let now = Date()
+        try repo.saveSession(makeSession(isbn: "111", start: now), bookISBN: "111")
+        try repo.saveSession(makeSession(isbn: "222", start: now), bookISBN: "222")
+
+        XCTAssertEqual(try repo.fetchMonthlyBookCount(), 2)
+    }
+
+    func test_총독서시간_합산() throws {
+        let now = Date()
+        try repo.saveSession(makeSession(isbn: "111", start: now), bookISBN: "111") // 300초
+        try repo.saveSession(makeSession(isbn: "222", start: now), bookISBN: "222") // 300초
+
+        XCTAssertEqual(try repo.fetchTotalSeconds(), 600)
+    }
+
+    func test_오늘세션이있으면_오늘읽음이_참이고_스트릭은1이상() throws {
+        try repo.saveSession(makeSession(isbn: "111", start: Date()), bookISBN: "111")
+
+        XCTAssertTrue(try repo.hasReadToday())
+        XCTAssertGreaterThanOrEqual(try repo.fetchCurrentStreak(), 1)
+    }
+
+    func test_세션이없으면_통계는_0() throws {
+        XCTAssertEqual(try repo.fetchReadDates().count, 0)
+        XCTAssertEqual(try repo.fetchMonthlyBookCount(), 0)
+        XCTAssertEqual(try repo.fetchCurrentStreak(), 0)
+        XCTAssertFalse(try repo.hasReadToday())
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOSTests/StreakCalculatorTests.swift
+++ b/LivingStory-iOS/LivingStory-iOSTests/StreakCalculatorTests.swift
@@ -1,0 +1,76 @@
+//
+//  StreakCalculatorTests.swift
+//  LivingStory-iOSTests
+//
+//  스트릭(연속 독서일) 순수 계산 로직 유닛 테스트.
+//  저장소·시계에 의존하지 않도록 today/calendar를 주입해 결정적으로 검증한다.
+//
+
+import XCTest
+@testable import LivingStory_iOS
+
+final class StreakCalculatorTests: XCTestCase {
+
+    private let cal = Calendar(identifier: .gregorian)
+    private func day(_ y: Int, _ m: Int, _ d: Int) -> Date {
+        cal.date(from: DateComponents(year: y, month: m, day: d))!
+    }
+
+    // MARK: - currentStreak
+
+    func test_currentStreak_빈집합이면_0() {
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: [], today: day(2026, 7, 18), calendar: cal), 0)
+    }
+
+    func test_currentStreak_오늘하루만_1() {
+        let today = day(2026, 7, 18)
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: [today], today: today, calendar: cal), 1)
+    }
+
+    func test_currentStreak_오늘까지_연속3일() {
+        let days: Set<Date> = [day(2026, 7, 16), day(2026, 7, 17), day(2026, 7, 18)]
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: days, today: day(2026, 7, 18), calendar: cal), 3)
+    }
+
+    func test_currentStreak_오늘미독서_어제까지연속이면_유지() {
+        // 듀오링고식 그레이스: 오늘 아직 안 읽었어도 어제 읽었으면 유지
+        let days: Set<Date> = [day(2026, 7, 16), day(2026, 7, 17)]
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: days, today: day(2026, 7, 18), calendar: cal), 2)
+    }
+
+    func test_currentStreak_어제도그제도미독서면_0() {
+        let days: Set<Date> = [day(2026, 7, 15), day(2026, 7, 16)]
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: days, today: day(2026, 7, 18), calendar: cal), 0)
+    }
+
+    func test_currentStreak_불연속이면_최근연속구간만_카운트() {
+        let days: Set<Date> = [day(2026, 7, 10), day(2026, 7, 17), day(2026, 7, 18)]
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: days, today: day(2026, 7, 18), calendar: cal), 2)
+    }
+
+    // MARK: - longestStreak
+
+    func test_longestStreak_최장연속구간() {
+        let days: Set<Date> = [day(2026, 7, 1), day(2026, 7, 2), day(2026, 7, 3),
+                               day(2026, 7, 10), day(2026, 7, 11)]
+        XCTAssertEqual(StreakCalculator.longestStreak(readDays: days, calendar: cal), 3)
+    }
+
+    func test_longestStreak_빈집합이면_0() {
+        XCTAssertEqual(StreakCalculator.longestStreak(readDays: [], calendar: cal), 0)
+    }
+
+    // MARK: - normalizedDays
+
+    func test_normalizedDays_서로다른날짜3개_3개로변환() {
+        let comps: Set<DateComponents> = [
+            DateComponents(year: 2026, month: 7, day: 16),
+            DateComponents(year: 2026, month: 7, day: 17),
+            DateComponents(year: 2026, month: 7, day: 18)
+        ]
+        let days = StreakCalculator.normalizedDays(from: comps, calendar: cal)
+        XCTAssertEqual(days.count, 3)
+        // startOfDay로 정규화되어 currentStreak과 합성 가능
+        XCTAssertEqual(StreakCalculator.currentStreak(readDays: days, today: day(2026, 7, 18), calendar: cal), 3)
+    }
+}


### PR DESCRIPTION
## 개요
핵심 로직에 대한 유닛 테스트와 네트워크 스텁 테스트를 추가했습니다. 실행 환경(실서버·특정 기기)에 의존하지 않고 결정적으로 도는 계층부터.

Closes #101

## 작업 내용
### 1. `StreakCalculatorTests` (순수 로직)
- currentStreak: 빈집합·오늘하루·연속·**오늘/어제 그레이스**·불연속 tail·경계
- longestStreak / normalizedDays

### 2. `ReadingSessionRepositoryTests` (인메모리 CoreData)
- 매 테스트마다 `NaruModel` /dev/null 스토어를 새로 띄워 격리
- 읽은 날짜 집계·같은날 중복 제거·월간 세션수·총 독서시간·오늘읽음/스트릭·빈 상태 0

### 3. `KakaoBookResponseDecodingTests` (네트워크 스텁)
- `URLProtocolStub`(재사용 가능)으로 카카오 응답 주입 → DTO 디코딩 계약 검증(정상·`total_count` snake_case·빈 결과)

## 확인
- [x] 테스트 타깃 컴파일 확인 (`build-for-testing`, TEST BUILD SUCCEEDED)
- [ ] 로컬 Xcode ⌘U 실행 (CI 환경 시뮬레이터 destination 이슈로 자동 실행은 로컬에서)

## 후속 (별도)
- `ISBNLookupService`/`GeminiService` end-to-end 스텁은 `NetworkService`가 `URLSession.shared` 고정이라 불가 → **세션 주입(기본값 `.shared`) 소규모 리팩터** 후 429/5xx→fallback 경로까지 테스트 확장 가능
