### PR TITLE
[Chore] [PO-103] QA 테스트 데이터 시드 + 시나리오 강제 실행 인자 (DEBUG)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
+++ b/LivingStory-iOS/LivingStory-iOS.xcodeproj/xcshareddata/xcschemes/LivingStory-iOS.xcscheme
@@ -79,6 +79,22 @@
             argument = "-UITestMockHome"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-SeedStreakData"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-MockBookNotFound"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-MockGemini429"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-MockGeminiServerError"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/LivingStory-iOS/LivingStory-iOS/Application/AppDelegate.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/AppDelegate.swift
@@ -12,6 +12,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        #if DEBUG
+        StreakDataSeeder.seedIfNeeded()   // -SeedStreakData 실행 시에만 동작
+        #endif
         return true
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
@@ -235,6 +235,9 @@ private extension ScannerViewController {
                 let startTime = Date()
 
                 do {
+                    #if DEBUG
+                    if LaunchArguments.mockBookNotFound { throw NetworkError.noData }   // QA: 책 조회 실패 강제
+                    #endif
                     // 책 조회(Kakao)는 필수 — 실패하면 바깥 catch → .failed (재시도/직접검색)
                     let book = try await ISBNLookupService.shared.lookupBook(isbn: isbn)
                     guard !Task.isCancelled else { return }
@@ -245,6 +248,10 @@ private extension ScannerViewController {
                     var conversations: [ConversationProfile] = []
                     var fallbackMessage: String? = nil
                     do {
+                        #if DEBUG
+                        if LaunchArguments.mockGemini429 { throw NetworkError.invalidResponse(statusCode: 429) }
+                        if LaunchArguments.mockGeminiServerError { throw NetworkError.invalidResponse(statusCode: 500) }
+                        #endif
                         async let envTask = self.geminiService.generateLightingAndMusic(for: book)
                         async let questionsTask = self.geminiService.generateQuestions(for: book, age: UserData.childAge)
                         let (env, conversationDTOs) = try await (envTask, questionsTask)

--- a/LivingStory-iOS/LivingStory-iOS/Testing/LaunchArguments.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Testing/LaunchArguments.swift
@@ -1,0 +1,28 @@
+//
+//  LaunchArguments.swift
+//  LivingStory-iOS
+//
+//  DEBUG 전용 QA 실행 인자. 스킴 ▸ Run ▸ Arguments Passed On Launch 에서 체크로 켜고 끈다.
+//  릴리즈 빌드엔 컴파일되지 않아 실서비스엔 영향이 없다.
+//
+
+#if DEBUG
+import Foundation
+
+enum LaunchArguments {
+
+    private static var args: [String] { ProcessInfo.processInfo.arguments }
+
+    /// 2026-07-03 ~ 오늘까지 "매일 다른 책 1권" 세션을 시드 (스트릭/달력/통계 채우기)
+    static var seedStreakData: Bool { args.contains("-SeedStreakData") }
+
+    /// 바코드 조회 실패를 강제 → 스캔 "실패" → 직접 검색 유도
+    static var mockBookNotFound: Bool { args.contains("-MockBookNotFound") }
+
+    /// Gemini 429(쿼터 초과) 실패 강제 → 기본 환경으로 진행 + 재추천 알럿
+    static var mockGemini429: Bool { args.contains("-MockGemini429") }
+
+    /// Gemini 5xx(서버) 실패 강제 → 기본 환경으로 진행
+    static var mockGeminiServerError: Bool { args.contains("-MockGeminiServerError") }
+}
+#endif

--- a/LivingStory-iOS/LivingStory-iOS/Testing/StreakDataSeeder.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Testing/StreakDataSeeder.swift
@@ -1,0 +1,74 @@
+//
+//  StreakDataSeeder.swift
+//  LivingStory-iOS
+//
+//  -SeedStreakData 실행 시, 2026-07-03 ~ 오늘까지 "매일 다른 책 1권"의 독서 세션을 시드한다.
+//  기존 세션·책을 지우고 새로 채워 결정적인 상태를 만든다. (DEBUG 전용)
+//
+
+#if DEBUG
+import CoreData
+
+enum StreakDataSeeder {
+
+    @MainActor
+    static func seedIfNeeded() {
+        guard LaunchArguments.seedStreakData else { return }
+
+        let context = PersistenceController.shared.context
+        wipe(["ReadingSessionEntity", "ConversationEntity", "BookEntity"], in: context)
+
+        let cal = Calendar(identifier: .gregorian)
+        let start = cal.date(from: DateComponents(year: 2026, month: 7, day: 3))!
+        let today = cal.startOfDay(for: Date())
+        let titles = ["구름빵", "달님 안녕", "괴물들이 사는 나라", "무지개 물고기",
+                      "돼지책", "알사탕", "코끼리 아저씨", "누가 내 머리에 똥 쌌어?",
+                      "지각대장 존", "손 큰 할머니의 만두 만들기"]
+
+        var day = start
+        var index = 0
+        while day <= today {
+            let readAt = cal.date(byAdding: .hour, value: 20, to: day) ?? day   // 그날 저녁 8시
+
+            let book = BookEntity(context: context)
+            book.isbn = "SEED-\(index)"
+            book.title = titles[index % titles.count]
+            book.author = "테스트 저자"
+            book.publisher = "테스트 출판사"
+            book.createdAt = readAt
+
+            let session = ReadingSessionEntity(context: context)
+            session.id = UUID()
+            session.startTime = readAt
+            session.endTime = cal.date(byAdding: .minute, value: 10, to: readAt)
+            session.duration = 600
+            session.createdAt = readAt
+            session.lightingHue = 40
+            session.lightingSaturation = 20
+            session.lightingBrightness = 80
+            session.musicCategory = MusicCategory.warm.rawValue
+            session.book = book
+
+            day = cal.date(byAdding: .day, value: 1, to: day) ?? today.addingTimeInterval(86_400)
+            index += 1
+        }
+
+        do {
+            try context.save()
+            print("[Seed] 스트릭 데이터 \(index)일치 시드 완료 (2026-07-03 ~ 오늘)")
+        } catch {
+            print("[Seed] 시드 저장 실패: \(error)")
+        }
+    }
+
+    /// 지정 엔티티의 모든 오브젝트를 삭제(컨텍스트 경유 — 인메모리/실 스토어 모두 안전).
+    private static func wipe(_ entities: [String], in context: NSManagedObjectContext) {
+        for name in entities {
+            let request = NSFetchRequest<NSManagedObject>(entityName: name)
+            if let objects = try? context.fetch(request) {
+                objects.forEach(context.delete)
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## 개요
QA/데모용 테스트 데이터 시드 + 시나리오 강제 실행 인자(모두 DEBUG 전용). #PO-101에서 예정으로 남겼던 항목.

Closes #114

## 작업 내용
- `StreakDataSeeder`(`-SeedStreakData`): 2026-07-03~오늘 매일 다른 책 세션 시드(기존 wipe 후) → 스트릭/달력/누적 즉시 채움
- 스캐너 시나리오 강제: `-MockBookNotFound`(책조회 실패→직접검색) / `-MockGemini429`·`-MockGeminiServerError`(추천 실패→기본환경 폴백)
- `LaunchArguments` 단일 파싱 지점, 스킴 `CommandLineArguments`에 4개 등록(기본 꺼짐, 체크로 토글)
- 릴리즈 빌드엔 `#if DEBUG`로 완전 배제

## 확인
- [x] 빌드 확인 (iOS Simulator, develop 기준)
