### PR TITLE
[Fix] [PO-104] 회귀 수정 — 스캐너 직접 검색 연결 복원

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Scanner/ScannerViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 // MARK: - Scanner State
 
@@ -36,6 +37,10 @@ final class ScannerViewController: BaseViewController {
     private var preparedEnvironment: PreparedEnvironment?
     private let geminiService = GeminiService()
     private var lookupTask: Task<Void, Never>?
+
+    /// 직접 검색 버튼 위치 제약 — 상태별 토글 (.scanning: 하단 / .failed: "다시 스캔" 위)
+    private var directSearchScanningConstraint: NSLayoutConstraint!
+    private var directSearchFailedConstraint: NSLayoutConstraint!
 
     let scanningDetent = UISheetPresentationController.Detent.custom(identifier: .init("scanning")) { context in
         context.maximumDetentValue * 0.75
@@ -191,10 +196,18 @@ private extension ScannerViewController {
             resultContentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             resultContentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            // 직접 검색 — safe area 바로 위, 중앙
-            directSearchButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8),
+            // 직접 검색 — 중앙 정렬 (세로 위치는 상태별 제약으로 토글)
             directSearchButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
+
+        // .scanning: safe area 바로 위 / .failed: "다시 스캔" 버튼 위
+        directSearchScanningConstraint = directSearchButton.bottomAnchor.constraint(
+            equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8
+        )
+        directSearchFailedConstraint = directSearchButton.bottomAnchor.constraint(
+            equalTo: resultContentView.retryButton.topAnchor, constant: -16
+        )
+        directSearchScanningConstraint.isActive = true
     }
 
     func setupActions() {
@@ -204,7 +217,30 @@ private extension ScannerViewController {
     }
 
     @objc func directSearchTapped() {
-        // TODO: 직접(수동) 책 검색 화면 연결 (검색 플로우 미구현)
+        let searchView = BookDirectSearchView(
+            onSelect: { [weak self] book in
+                guard let self else { return }
+                // 검색 시트를 먼저 닫고, 기존 바코드 성공 플로우를 그대로 재사용
+                self.dismiss(animated: true) {
+                    self.fetchedBook = book
+                    self.state = .success
+                }
+            },
+            onClose: { [weak self] in
+                self?.dismiss(animated: true)
+            }
+        )
+
+        let hostingVC = UIHostingController(rootView: searchView)
+        hostingVC.view.backgroundColor = UIColor(hex: 0x1C1C1E)
+
+        if let sheet = hostingVC.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.preferredCornerRadius = 32
+            sheet.prefersGrabberVisible = true
+        }
+
+        present(hostingVC, animated: true)
     }
 }
 
@@ -315,8 +351,12 @@ private extension ScannerViewController {
         scanningContentView.alpha = state == .scanning ? 1 : 0
         scanningContentView.isHidden = state != .scanning
 
-        // 직접 검색은 스캐닝 상태에서만
-        directSearchButton.isHidden = state != .scanning
+        // 직접 검색은 스캐닝 + 실패 상태에서 노출
+        directSearchButton.isHidden = !(state == .scanning || state == .failed)
+
+        // 위치 제약 토글: 실패 상태에선 "다시 스캔" 위로, 그 외엔 하단
+        directSearchScanningConstraint.isActive = (state != .failed)
+        directSearchFailedConstraint.isActive = (state == .failed)
 
         resultContentView.alpha = state == .scanning ? 0 : 1
         resultContentView.isHidden = state == .scanning


### PR DESCRIPTION
## 개요
PO-96(#109) 머지 과정에서 `ScannerViewController` 전체 교체로 **PO-91 직접 검색 연결이 TODO 스텁으로 회귀**했던 걸 복원합니다. (빌드는 통과해 지나갔고, 이번 크로스체크에서 마커 검증으로 발견)

Closes #116

## 복원 (PO-96 폴백 · PO-103 목 훅은 유지)
- `import SwiftUI`
- `directSearchScanningConstraint`/`FailedConstraint` + 상태별 토글
- `directSearchTapped()` → `BookDirectSearchView` 시트
- 직접 검색 버튼을 `.scanning` + `.failed` 상태에서 노출

## 확인
- [x] 빌드 성공, 마커 공존 검증(SwiftUI/directSearch/preparedEnvironment/mockBookNotFound)
