### PR TITLE
[Fix] [PO-105] Release+시뮬레이터 빌드 실패 수정 (MockLightingController 가드)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Models/LightingConfig.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Models/LightingConfig.swift
@@ -45,7 +45,9 @@ protocol LightingControllable {
     func stopBrightnessPulse() async
 }
 
-#if DEBUG
+// 시뮬레이터엔 HomeKit이 없어 Release+시뮬 빌드에서도 필요 → DEBUG뿐 아니라 simulator에서도 컴파일.
+// (실기기 Release에선 제외 — AppCoordinator가 HomeKitLightingController 사용)
+#if DEBUG || targetEnvironment(simulator)
 struct MockLightingController: LightingControllable {
     func applyLighting(_ config: LightingConfig) async throws {
         print("[MockLighting] 조명 적용 - H\(config.hue) S\(config.saturation) B\(config.brightness)")


### PR DESCRIPTION
Closes #118

## 문제
Release 구성으로 시뮬레이터 빌드 시 `MockLightingController` not in scope. `#if DEBUG` 심볼을 `#if targetEnvironment(simulator)` 조건에서 참조한 불일치.

## 수정
가드를 `#if DEBUG || targetEnvironment(simulator)`로 확장.

## 확인
- [x] Release + 시뮬레이터 BUILD SUCCEEDED
- [x] Release + 실기기(배포 아카이브 config) BUILD SUCCEEDED