### PR TITLE
[Fix] [PO-106] MainActor 격리 정리 (HomeKit 델리게이트·병합정책·Shape static)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/CheckmarkTransitionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/CheckmarkTransitionView.swift
@@ -109,7 +109,7 @@ struct AnimatedCheckmark: View {
 
 /// 체크 fill 도형과 마스크용 중심선(spine)을 담고, 둘 다 "글리프 실제 경계 기준" 동일 변환으로
 /// rect 중앙에 정렬한다. → 어떤 frame에서도 가로·세로 정중앙, fill·spine은 정확히 겹침.
-private enum CheckArt {
+private nonisolated enum CheckArt {
     static let design = CGSize(width: 96, height: 77)
 
     /// 체크 글리프의 실제(on-path) 바운딩. Figma 절대좌표는 96×77 박스 안에서 위로 치우쳐 있어

--- a/LivingStory-iOS/LivingStory-iOS/Core/Persistence/PersistenceController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Persistence/PersistenceController.swift
@@ -39,7 +39,7 @@ final class PersistenceController {
         }
         
         container.viewContext.automaticallyMergesChangesFromParent = true
-        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
     }
     
     //MARK: 실제 SQLite에 저장하는 함수

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -92,25 +92,19 @@ final class HomeKitManager: NSObject, HomeDataProviding {
 
 extension HomeKitManager: HMHomeDelegate {
     
-    func home(_ home: HMHome, didAdd accessory: HMAccessory) {
-        accessory.delegate = self
-
-        Task {
+    nonisolated func home(_ home: HMHome, didAdd accessory: HMAccessory) {
+        Task { @MainActor in
+            accessory.delegate = self
             await enableNotifications(for: accessory)
-
             let homes = homeManager.homes.map { mapHome($0) }
-            await MainActor.run {
-                onHomesUpdated?(homes)
-            }
+            onHomesUpdated?(homes)
         }
     }
 
-    func home(_ home: HMHome, didRemove accessory: HMAccessory) {
-        Task {
+    nonisolated func home(_ home: HMHome, didRemove accessory: HMAccessory) {
+        Task { @MainActor in
             let homes = homeManager.homes.map { mapHome($0) }
-            await MainActor.run {
-                onHomesUpdated?(homes)
-            }
+            onHomesUpdated?(homes)
         }
     }
 }
@@ -119,14 +113,14 @@ extension HomeKitManager: HMHomeDelegate {
 
 extension HomeKitManager: HMHomeManagerDelegate {
 
-    func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
-        handleStatus(manager.authorizationStatus)
+    nonisolated func homeManagerDidUpdateHomes(_ manager: HMHomeManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in handleStatus(status) }
     }
 
-    func homeManager(_ manager: HMHomeManager, didUpdate status: HMHomeManagerAuthorizationStatus) {
-        if status.contains(.determined) {
-            handleStatus(status)
-        }
+    nonisolated func homeManager(_ manager: HMHomeManager, didUpdate status: HMHomeManagerAuthorizationStatus) {
+        guard status.contains(.determined) else { return }
+        Task { @MainActor in handleStatus(status) }
     }
 }
 
@@ -160,15 +154,17 @@ private extension HomeKitManager {
 extension HomeKitManager: HMAccessoryDelegate {
 
     /// 액세서리의 특성 값이 변경되면 호출 (외부 앱, 자동화, 물리 제어 등)
-    func accessory(_ accessory: HMAccessory, service: HMService,
-                   didUpdateValueFor characteristic: HMCharacteristic) {
+    nonisolated func accessory(_ accessory: HMAccessory, service: HMService,
+                               didUpdateValueFor characteristic: HMCharacteristic) {
         // 디바운싱: 150ms 내 연속 변경을 최종 1회로 합침 (밝기 슬라이더 등)
-        pendingUpdateTask?.cancel()
-        pendingUpdateTask = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(150))
-            guard !Task.isCancelled else { return }
-            let homes = homeManager.homes.map { mapHome($0) }
-            onHomesUpdated?(homes)
+        Task { @MainActor in
+            pendingUpdateTask?.cancel()
+            pendingUpdateTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                let homes = homeManager.homes.map { mapHome($0) }
+                onHomesUpdated?(homes)
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #122

## 수정
- **HomeKitManager**: HomeKit 델리게이트 메서드를 `nonisolated` + `Task { @MainActor }` 홉으로 (기본격리 MainActor ↔ nonisolated 프로토콜 요구 충돌 해소)
- **PersistenceController**: 전역 `NSMergeByPropertyObjectTrumpMergePolicy` → `NSMergePolicy.mergeByPropertyObjectTrump`
- **CheckmarkTransitionView**: Shape가 참조하는 `CheckArt`를 `nonisolated`로

## 확인
- [x] 프로젝트 실제 설정(Swift 5) BUILD SUCCEEDED, 동작 보존

> EnvironmentPreviewView 연산자 애매성은 이토 담당이라 이 PR에서 제외.