### PR TITLE
[Refactor] [PO-107] HomeKitManager 단일 공유 인스턴스 (멀티캐스트 구독)

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Application/AppDelegate.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/AppDelegate.swift
@@ -8,6 +8,11 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    /// 앱당 단일 홈 데이터 소스(= HMHomeManager 1개). 프로세스당 1개인 AppDelegate가 소유해
+    /// scene 재연결·멀티윈도우와 무관하게 단일성을 보장한다. lazy라 첫 접근(온보딩) 전엔 생성 안 됨
+    /// → 권한 다이얼로그 타이밍 보존. didFinishLaunching에서는 절대 접근하지 않는다.
+    lazy var homeProvider: HomeDataProviding = HomeProviderFactory.make()
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?

--- a/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Application/Coordinator/AppCoordinator.swift
@@ -16,6 +16,13 @@ final class AppCoordinator: Coordinator {
     private var tabBarController: MainTabBarController?
     private(set) var activeReadingViewModel: ReadingViewModel?
 
+    /// 앱당 단일 공유 홈 데이터 소스. 소유자는 AppDelegate(프로세스당 1개)이며 여기선 읽기만 한다.
+    /// 실기 앱에선 항상 AppDelegate.homeProvider(lazy 단일 인스턴스)를 반환.
+    /// (프리뷰/테스트 등 delegate가 AppDelegate가 아닌 문맥에서만 폴백 — 실앱 단일성엔 영향 없음)
+    var homeProvider: HomeDataProviding {
+        (UIApplication.shared.delegate as? AppDelegate)?.homeProvider ?? HomeProviderFactory.make()
+    }
+
     init(navigationController: UINavigationController) {
         self.navigationController = navigationController
     }
@@ -37,7 +44,7 @@ final class AppCoordinator: Coordinator {
 
         // Tab 1: 환경 세팅
         let homeNav = UINavigationController()
-        let homeVC = HomeViewController()
+        let homeVC = HomeViewController(homeProvider: homeProvider)
         homeVC.coordinator = self
         homeNav.setViewControllers([homeVC], animated: false)
         homeNav.tabBarItem = UITabBarItem(
@@ -271,7 +278,7 @@ final class AppCoordinator: Coordinator {
 
     /// 첫 실행 환경 세팅 플로우 (SwiftUI) — VM 생성·완료 와이어링·주입은 여기서
     func showOnboardingSetting() {
-        let viewModel = OnboardingFlowViewModel()
+        let viewModel = OnboardingFlowViewModel(homeProvider: homeProvider)
         viewModel.onCompleted = { [weak self] in
             self?.enterMain()
         }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Home/HomeViewController.swift
@@ -13,8 +13,9 @@ final class HomeViewController: BaseViewController {
 
     weak var coordinator: AppCoordinator?
 
-    // 실제(HomeKitManager) 또는 목업(MockHomeProvider) — 실행 인자로 결정 (DEBUG)
-    private let homeProvider: HomeDataProviding = HomeProviderFactory.make()
+    // 앱당 단일 공유 프로바이더를 주입받음 (AppCoordinator가 AppDelegate의 것을 전달)
+    private let homeProvider: HomeDataProviding
+    private var homeObservation: HomeObservation?
     private let homeDataSource = HomeDataSource()
     private var homes: [HomeModel] = []
     private var currentHome: HomeModel?
@@ -51,6 +52,18 @@ final class HomeViewController: BaseViewController {
         view.isHidden = true
         return view
     }()
+
+    // MARK: - Init
+
+    init(homeProvider: HomeDataProviding) {
+        self.homeProvider = homeProvider
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -239,31 +252,33 @@ extension HomeViewController: UICollectionViewDelegate {
 private extension HomeViewController {
 
     func bindHomeKit() {
-        homeProvider.onHomesUpdated = { [weak self] homes in
-            guard let self else { return }
-            self.homes = homes
+        // 공유 프로바이더에 구독. addObserver가 등록 직후 현재 상태를 1회 전달하고,
+        // 미결정이면 내부에서 상태 확인을 트리거 → HomeVC가 첫 소비자여도(둘 다 완료 재실행) 초기 렌더 보장.
+        homeObservation = homeProvider.addObserver(
+            self,
+            onHomesUpdated: { [weak self] homes in
+                guard let self else { return }
+                self.homes = homes
 
-            // 현재 선택된 집 유지 (실시간 업데이트 시 리셋 방지)
-            if let selectedId = self.currentHome?.id,
-               let updated = homes.first(where: { $0.id == selectedId }) {
-                self.currentHome = updated
-                self.updateUI(for: updated.state)
-            } else if let first = homes.first {
-                self.currentHome = first
-                self.updateUI(for: first.state)
-            } else {
-                self.currentHome = nil
-                self.updateUI(for: .noDevices)
+                // 현재 선택된 집 유지 (실시간 업데이트 시 리셋 방지)
+                if let selectedId = self.currentHome?.id,
+                   let updated = homes.first(where: { $0.id == selectedId }) {
+                    self.currentHome = updated
+                    self.updateUI(for: updated.state)
+                } else if let first = homes.first {
+                    self.currentHome = first
+                    self.updateUI(for: first.state)
+                } else {
+                    self.currentHome = nil
+                    self.updateUI(for: .noDevices)
+                }
+            },
+            onPermissionDenied: { [weak self] in
+                self?.homes = []
+                self?.currentHome = nil
+                self?.updateUI(for: .permissionsRequired)
             }
-        }
-
-        homeProvider.onPermissionDenied = { [weak self] in
-            self?.homes = []
-            self?.currentHome = nil
-            self?.updateUI(for: .permissionsRequired)
-        }
-
-        homeProvider.checkInitialStatus()
+        )
     }
 }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Onboarding/OnboardingViewController.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Onboarding/OnboardingViewController.swift
@@ -21,7 +21,8 @@ final class OnboardingViewController: BaseViewController {
     // MARK: - Properties
 
     weak var coordinator: AppCoordinator?
-    private var homeKitManager: HomeKitManager?
+    private var homeObservation: HomeObservation?
+    private var didProceed = false
     
     override var backgroundStyle: ScreenBackgroundColor { .primary }
     
@@ -101,13 +102,14 @@ private extension OnboardingViewController {
     /// HomeKitManager(서비스) 초기화로 권한 다이얼로그를 띄우고,
     /// 권한 결과(허용/거부)와 무관하게 메인으로 진입한다.
     func requestHomeKitPermission() {
-        let manager = HomeKitManager()
-        homeKitManager = manager
-        manager.onHomesUpdated = { [weak self] _ in self?.proceedToMain() }
-        manager.onPermissionDenied = { [weak self] in self?.proceedToMain() }
-
-        // 이미 권한이 결정된 상태면 즉시 콜백 → 바로 진입
-        manager.checkInitialStatus()
+        // coordinator.homeProvider 첫 접근 = AppDelegate lazy 생성 = 권한 다이얼로그 트리거 앵커.
+        guard homeObservation == nil, let provider = coordinator?.homeProvider else { return }
+        homeObservation = provider.addObserver(
+            self,
+            onHomesUpdated: { [weak self] _ in self?.proceedToMain() },
+            onPermissionDenied: { [weak self] in self?.proceedToMain() }
+        )
+        // checkInitialStatus 직접 호출 불필요 — addObserver가 미결정 시 내부 트리거.
     }
 }
 
@@ -116,9 +118,11 @@ private extension OnboardingViewController {
 private extension OnboardingViewController {
 
     func proceedToMain() {
-        // 중복 호출 방지
-        guard homeKitManager != nil else { return }
-        homeKitManager = nil
+        // 중복 호출 방지 (didProceed가 단일 진실). 공유 인스턴스는 nil 금지 — 콜백만 해지.
+        guard !didProceed else { return }
+        didProceed = true
+        homeObservation?.cancel()
+        homeObservation = nil
 
         UserData.hasCompletedOnboarding = true
         coordinator?.completeOnboarding()

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/ViewModel/OnboardingFlowViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/OnboardingSetting/ViewModel/OnboardingFlowViewModel.swift
@@ -36,10 +36,12 @@ final class OnboardingFlowViewModel {
     private var deniedTask: Task<Void, Never>?
 
     // MARK: - Dependencies
-    private let homeKit = HomeKitManager()
+    private let homeProvider: HomeDataProviding
+    private var homeObservation: HomeObservation?
     private let repository: EnvironmentSettingRepositoryProtocol
 
-    init(repository: EnvironmentSettingRepositoryProtocol? = nil) {
+    init(homeProvider: HomeDataProviding, repository: EnvironmentSettingRepositoryProtocol? = nil) {
+        self.homeProvider = homeProvider
         // @MainActor 타입이라 기본 인자가 아닌 init 본문(@MainActor)에서 생성
         self.repository = repository ?? EnvironmentSettingRepository()
         bindHomeKit()
@@ -188,13 +190,13 @@ final class OnboardingFlowViewModel {
     // MARK: - Private: HomeKit binding
 
     private func bindHomeKit() {
-        homeKit.onPermissionDenied = { [weak self] in
-            self?.scheduleDeniedIfNeeded()
-        }
-        homeKit.onHomesUpdated = { [weak self] homes in
-            self?.handleHomes(homes)
-        }
-        homeKit.checkInitialStatus()
+        // 공유 프로바이더에 구독. addObserver가 등록 직후 현재 상태를 1회 전달하고,
+        // 미결정이면 내부에서 checkInitialStatus를 트리거 → VM이 첫 소비자여도(재개-투-세팅) 안 멈춤.
+        homeObservation = homeProvider.addObserver(
+            self,
+            onHomesUpdated: { [weak self] homes in self?.handleHomes(homes) },
+            onPermissionDenied: { [weak self] in self?.scheduleDeniedIfNeeded() }
+        )
     }
 
     /// 거부 신호를 400ms 디바운스 — 그 안에 homes가 오면(권한 OK) #27을 띄우지 않는다.

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeDataProviding.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeDataProviding.swift
@@ -2,19 +2,28 @@
 //  HomeDataProviding.swift
 //  LivingStory-iOS
 //
-//  HomeViewController가 의존하는 "집/기기 데이터 소스" 추상화.
-//  실제(HomeKitManager)와 목업(MockHomeProvider)을 갈아끼워 UI를 테스트한다.
+//  "집/기기 데이터 소스" 추상화. 실제(HomeKitManager)와 목업(MockHomeProvider)을 갈아끼운다.
+//  콜백은 단일 클로저가 아니라 addObserver(멀티캐스트)로 받아, 여러 소비처가 하나의 공유
+//  인스턴스를 덮어쓰지 않고 각자 구독한다. (앱당 HMHomeManager 1개 — Apple 가이드라인)
 //
 
 import Foundation
 
+@MainActor
 protocol HomeDataProviding: AnyObject {
-    /// 집 목록 갱신 콜백 (항상 메인에서 호출)
-    var onHomesUpdated: (@MainActor ([HomeModel]) -> Void)? { get set }
-    /// 권한 거부 콜백 (항상 메인에서 호출)
-    var onPermissionDenied: (@MainActor () -> Void)? { get set }
+    /// 마지막으로 알려진 집 목록 (권한 미결정/거부면 빈 배열). 즉시 동기 조회용.
+    var currentHomes: [HomeModel] { get }
 
-    /// 초기 상태 확인 → 준비되면 onHomesUpdated/onPermissionDenied 호출
+    /// 집 목록/권한 변화를 구독. owner를 weak로 잡아 dealloc 시 자동 정리한다.
+    /// 등록 직후(다음 틱) 현재 상태를 1회 전달하고, 미결정이면 내부에서 상태 확인을 트리거한다.
+    @discardableResult
+    func addObserver(
+        _ owner: AnyObject,
+        onHomesUpdated: @escaping @MainActor ([HomeModel]) -> Void,
+        onPermissionDenied: @escaping @MainActor () -> Void
+    ) -> HomeObservation
+
+    /// 초기 상태 확인 → 준비되면 구독자에게 방송 (보통 addObserver가 내부에서 호출)
     func checkInitialStatus()
     /// 기기 전원을 목표값으로 설정 (실패/타임아웃 시 throw → 호출부 롤백)
     func setPower(_ isOn: Bool, for deviceId: UUID, timeout: TimeInterval) async throws
@@ -32,9 +41,9 @@ extension HomeDataProviding {
 // MARK: - Factory
 
 enum HomeProviderFactory {
-    /// 실행 인자/환경변수로 목업 데이터 주입 (DEBUG 빌드에서만).
-    ///   • Xcode Scheme ▸ Run ▸ Arguments 에 `-UITestMockHome` 추가, 또는
-    ///   • 환경변수 `MOCK_HOME=1`, 또는 XCUITest `app.launchArguments = ["-UITestMockHome"]`
+    /// 앱 전역에서 딱 1번 호출되어야 함 (AppDelegate.homeProvider가 소유).
+    /// DEBUG + 실행 인자 `-UITestMockHome` 또는 환경변수 `MOCK_HOME=1`이면 목업 주입.
+    @MainActor
     static func make() -> HomeDataProviding {
         #if DEBUG
         let args = ProcessInfo.processInfo.arguments

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeKitManager.swift
@@ -26,11 +26,61 @@ final class HomeKitManager: NSObject, HomeDataProviding {
     private let homeManager = HMHomeManager()
     private var pendingUpdateTask: Task<Void, Never>?
 
-    /// HomeKit에서 집 목록이 업데이트되면 호출되는 콜백 (항상 메인에서 호출 — 타입으로 강제)
-    var onHomesUpdated: (@MainActor ([HomeModel]) -> Void)?
+    // MARK: - Multicast (여러 소비처가 각자 구독 — 단일 클로저 덮어쓰기 방지)
 
-    /// HomeKit 권한이 거부되었을 때 호출되는 콜백 (항상 메인에서 호출 — 타입으로 강제)
-    var onPermissionDenied: (@MainActor () -> Void)?
+    private enum LastHomeState { case unknown, homes([HomeModel]), denied }
+    private var lastState: LastHomeState = .unknown
+
+    private struct Observer {
+        weak var owner: AnyObject?
+        let onHomes: @MainActor ([HomeModel]) -> Void
+        let onDenied: @MainActor () -> Void
+    }
+    private var observers: [UUID: Observer] = [:]
+
+    var currentHomes: [HomeModel] {
+        if case .homes(let h) = lastState { return h } else { return [] }
+    }
+
+    @discardableResult
+    func addObserver(_ owner: AnyObject,
+                     onHomesUpdated: @escaping @MainActor ([HomeModel]) -> Void,
+                     onPermissionDenied: @escaping @MainActor () -> Void) -> HomeObservation {
+        let id = UUID()
+        observers[id] = Observer(owner: owner, onHomes: onHomesUpdated, onDenied: onPermissionDenied)
+        // 초기 전달을 다음 틱으로 미뤄 호출부 토큰 대입이 먼저 끝나게 함(#4).
+        // 미결정이면 checkInitialStatus를 내부 트리거해 '첫 소비자'가 반드시 초기값을 받게 함(#1).
+        Task { @MainActor [weak self] in
+            guard let self, self.observers[id] != nil else { return }
+            switch self.lastState {
+            case .homes(let h): onHomesUpdated(h)
+            case .denied: onPermissionDenied()
+            case .unknown: self.checkInitialStatus()
+            }
+        }
+        return HomeObservation { [weak self] in self?.observers[id] = nil }
+    }
+
+    /// 스냅샷 순회(#5) — 콜백 중 구독 취소/추가가 순회를 변형하지 못하게. dead(owner==nil)는 사후 프루닝.
+    private func emitHomes(_ homes: [HomeModel]) {
+        lastState = .homes(homes)
+        let snapshot = observers
+        var dead: [UUID] = []
+        for (id, o) in snapshot {
+            if o.owner == nil { dead.append(id) } else { o.onHomes(homes) }
+        }
+        for id in dead { observers[id] = nil }
+    }
+
+    private func emitDenied() {
+        lastState = .denied
+        let snapshot = observers
+        var dead: [UUID] = []
+        for (id, o) in snapshot {
+            if o.owner == nil { dead.append(id) } else { o.onDenied() }
+        }
+        for id in dead { observers[id] = nil }
+    }
 
     // MARK: - Init
 
@@ -97,14 +147,14 @@ extension HomeKitManager: HMHomeDelegate {
             accessory.delegate = self
             await enableNotifications(for: accessory)
             let homes = homeManager.homes.map { mapHome($0) }
-            onHomesUpdated?(homes)
+            emitHomes(homes)
         }
     }
 
     nonisolated func home(_ home: HMHome, didRemove accessory: HMAccessory) {
         Task { @MainActor in
             let homes = homeManager.homes.map { mapHome($0) }
-            onHomesUpdated?(homes)
+            emitHomes(homes)
         }
     }
 }
@@ -131,7 +181,7 @@ private extension HomeKitManager {
     func handleStatus(_ status: HMHomeManagerAuthorizationStatus) {
         guard status.contains(.authorized) else {
             Task { @MainActor in
-                onPermissionDenied?()
+                emitDenied()
             }
             return
         }
@@ -143,7 +193,7 @@ private extension HomeKitManager {
 
             let homes = homeManager.homes.map { mapHome($0) }
             await MainActor.run {
-                onHomesUpdated?(homes)
+                emitHomes(homes)
             }
         }
     }
@@ -163,7 +213,7 @@ extension HomeKitManager: HMAccessoryDelegate {
                 try? await Task.sleep(for: .milliseconds(150))
                 guard !Task.isCancelled else { return }
                 let homes = homeManager.homes.map { mapHome($0) }
-                onHomesUpdated?(homes)
+                emitHomes(homes)
             }
         }
     }

--- a/LivingStory-iOS/LivingStory-iOS/Service/HomeObservation.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Service/HomeObservation.swift
@@ -1,0 +1,24 @@
+//
+//  HomeObservation.swift
+//  LivingStory-iOS
+//
+//  공유 HomeDataProviding 구독 토큰. 소비처가 strong으로 보유하고, 화면이 사라지거나
+//  더 이상 필요 없을 때 cancel()로 콜백을 끊는다. (공유 인스턴스 자체는 nil 하지 않음)
+//  deinit 자동 해지는 두지 않는다 — 프로바이더가 owner를 weak로 잡아 dealloc 시 자동 프루닝하므로.
+//
+
+import Foundation
+
+@MainActor
+final class HomeObservation {
+    private var onCancel: (() -> Void)?
+
+    init(onCancel: @escaping () -> Void) {
+        self.onCancel = onCancel
+    }
+
+    func cancel() {
+        onCancel?()
+        onCancel = nil
+    }
+}

--- a/LivingStory-iOS/LivingStory-iOS/Testing/MockHomeProvider.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Testing/MockHomeProvider.swift
@@ -4,46 +4,80 @@
 //
 //  HomeKit 없이 UI를 구동하는 가짜 프로바이더 (DEBUG 전용).
 //  실제 기기 왕복을 흉내내는 지연을 넣어 옵티미스틱 UI·켜짐 애니메이션을 검증할 수 있다.
+//  실제(HomeKitManager)와 동일한 멀티캐스트 계약을 따른다.
 //
 
 #if DEBUG
 import Foundation
 
-final class MockHomeProvider: HomeDataProviding, @unchecked Sendable {
+@MainActor
+final class MockHomeProvider: HomeDataProviding {
 
-    var onHomesUpdated: (@MainActor ([HomeModel]) -> Void)?
-    var onPermissionDenied: (@MainActor () -> Void)?
+    private enum LastHomeState { case unknown, homes([HomeModel]), denied }
+    private var lastState: LastHomeState = .unknown
 
-    private let lock = NSLock()
+    private struct Observer {
+        weak var owner: AnyObject?
+        let onHomes: @MainActor ([HomeModel]) -> Void
+        let onDenied: @MainActor () -> Void
+    }
+    private var observers: [UUID: Observer] = [:]
+
     private var homes = MockHomeData.makeHomes()
 
+    var currentHomes: [HomeModel] {
+        if case .homes(let h) = lastState { return h } else { return [] }
+    }
+
+    @discardableResult
+    func addObserver(_ owner: AnyObject,
+                     onHomesUpdated: @escaping @MainActor ([HomeModel]) -> Void,
+                     onPermissionDenied: @escaping @MainActor () -> Void) -> HomeObservation {
+        let id = UUID()
+        observers[id] = Observer(owner: owner, onHomes: onHomesUpdated, onDenied: onPermissionDenied)
+        // 초기 전달을 다음 틱으로 미뤄 호출부 토큰 대입이 먼저 끝나게 함
+        Task { @MainActor [weak self] in
+            guard let self, self.observers[id] != nil else { return }
+            switch self.lastState {
+            case .homes(let h): onHomesUpdated(h)
+            case .denied: onPermissionDenied()
+            case .unknown: self.checkInitialStatus()   // 첫 소비자 보장 (Mock은 항상 허용)
+            }
+        }
+        return HomeObservation { [weak self] in self?.observers[id] = nil }
+    }
+
+    /// 권한 허용 흐름 흉내 — 첫 소비자가 안 멈추도록 즉시 홈 방송
     func checkInitialStatus() {
-        emit()
+        emitHomes(homes)
     }
 
     func setPower(_ isOn: Bool, for deviceId: UUID, timeout: TimeInterval) async throws {
         // 실제 기기 왕복 흉내 (옵티미스틱 UI/글로우 애니메이션 확인용)
         try? await Task.sleep(for: .milliseconds(300))
-        // async 안에서는 lock()/unlock() 직접 호출 금지 → 스코프 락 사용
-        lock.withLock {
-            outer: for h in homes.indices {
-                for r in homes[h].rooms.indices {
-                    if let i = homes[h].rooms[r].devices.firstIndex(where: { $0.id == deviceId }) {
-                        homes[h].rooms[r].devices[i].isOn = isOn
-                        break outer
-                    }
+        // 전 구간 MainActor라 락 불필요
+        outer: for h in homes.indices {
+            for r in homes[h].rooms.indices {
+                if let i = homes[h].rooms[r].devices.firstIndex(where: { $0.id == deviceId }) {
+                    homes[h].rooms[r].devices[i].isOn = isOn
+                    break outer
                 }
             }
         }
     }
 
     func refreshAllCharacteristics() async {
-        emit()
+        emitHomes(homes)
     }
 
-    private func emit() {
-        let snapshot = lock.withLock { homes }
-        Task { @MainActor in onHomesUpdated?(snapshot) }
+    private func emitHomes(_ homes: [HomeModel]) {
+        lastState = .homes(homes)
+        let snapshot = observers
+        var dead: [UUID] = []
+        for (id, o) in snapshot {
+            if o.owner == nil { dead.append(id) } else { o.onHomes(homes) }
+        }
+        for id in dead { observers[id] = nil }
     }
 }
 #endif


### PR DESCRIPTION
Closes #124

팀 설계 + 적대적 크로스체크 2회로 확정한 리팩터.

## 핵심
- **소유**: AppDelegate.homeProvider(lazy) → 앱당 HMHomeManager 1개(Apple 가이드라인). 3곳 직접 생성 제거
- **구독**: 단일 클로저 → addObserver(owner:) 멀티캐스트(HomeObservation 토큰). 소비처끼리 콜백 덮어쓰기 불가, owner-weak 자동 정리
- **첫 소비자 보장**: addObserver가 다음 틱에 현재상태 전달, 미결정이면 checkInitialStatus 내부 트리거
- **Mock 유지**: -UITestMockHome 주입 그대로, 온보딩까지 앱 전역 단일 Mock 공유(반쪽 버그 수정)

## 확인
- [x] Debug 빌드
- [x] Release 빌드(실기기, MockHomeProvider #if DEBUG 제외)
- [x] 유닛테스트 통과

적대적 검증 must-fix 5건 전부 반영. (리뷰용 — 머지 대기)
