### PR TITLE
[Refactor] [PO-108] 설정 화면 하드코딩 제거 — 나이 데이터 연결 + 리터럴 토큰화

### DIFF
--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/BookStackAnimationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/BookStackAnimationView.swift
@@ -67,18 +67,6 @@ struct BookStackAnimationView: View {
     }
 }
 
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
-}
-
 #Preview {
     ZStack {
         Color.black.ignoresSafeArea()

--- a/LivingStory-iOS/LivingStory-iOS/Core/Components/MultiSelectCalendarView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Components/MultiSelectCalendarView.swift
@@ -261,18 +261,6 @@ private struct MonthYearPickerSheet: View {
     }
 }
 
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
-}
-
 #Preview {
     let cal = Calendar(identifier: .gregorian)
     let today = cal.startOfDay(for: Date())

--- a/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Core/Consts/StringLiterals.swift
@@ -152,6 +152,8 @@ enum StringLiterals {
         static let notificationHeadline = "몇시에 책을 읽어주실 건가요?"
         static let notificationSubtitle = "매일 설정한 시간에 알람을 드릴게요"
         static let notificationToggle = "알림 설정"
+        static let notificationDeniedNotice = "알림이 꺼져 있어요. 설정 > 나루 > 알림에서 켜주세요"
+        static let openSettings = "설정"
 
         static let homeTitle = "집 선택"
         static let homeHeadline = "어디에서 사용할 건가요?"

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ConversationView.swift
@@ -124,18 +124,6 @@ private struct ConversationAccordionCard: View {
     }
 }
 
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
-}
-
 // MARK: - Preview
 
 #if DEBUG

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingView.swift
@@ -476,14 +476,6 @@ private struct TickSlider: View {
 
 private extension Color {
     static let fillTertiary = Color(red: 118 / 255, green: 118 / 255, blue: 128 / 255).opacity(0.24)
-
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
 }
 
 // MARK: - Preview

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/ReadingViewModel.swift
@@ -21,9 +21,6 @@ struct PreparedEnvironment: Sendable {
 @Observable
 final class ReadingViewModel {
 
-    // TODO: 아이 나이 입력(설정) 구현 후 UserData에서 읽어오도록 교체. 현재는 임시 상수.
-    private static let childAge = 6
-
     let book: BookProfileModel
     private(set) var state: ReadingState = .setting
     private(set) var isLightingReady = false
@@ -147,7 +144,7 @@ final class ReadingViewModel {
         var music: MusicCategory = .warm
         var convos: [ConversationProfile] = []
         do {
-            async let questionsTask = geminiService.generateQuestions(for: book, age: Self.childAge)
+            async let questionsTask = geminiService.generateQuestions(for: book, age: UserData.childAge)
             async let environmentTask = geminiService.generateLightingAndMusic(for: book)
             let (conversationDTOs, environment) = try await (questionsTask, environmentTask)
             lighting = environment.lighting
@@ -192,7 +189,7 @@ final class ReadingViewModel {
     func retryAIRecommendation() async {
         aiFallbackMessage = nil
         do {
-            async let questionsTask = geminiService.generateQuestions(for: book, age: Self.childAge)
+            async let questionsTask = geminiService.generateQuestions(for: book, age: UserData.childAge)
             async let environmentTask = geminiService.generateLightingAndMusic(for: book)
             let (conversationDTOs, environment) = try await (questionsTask, environmentTask)
             lightingConfig = environment.lighting

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Reading/StopReadingView.swift
@@ -112,18 +112,6 @@ struct StopReadingView: View {
     }
 }
 
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
-}
-
 // MARK: - Preview
 
 #if DEBUG

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/ChildAgeSettingView.swift
@@ -2,7 +2,7 @@
 //  ChildAgeSettingView.swift
 //  LivingStory-iOS
 //
-//  아이 나이 설정 (디자인 897-4862) — 현재 UI만, 값 더미
+//  아이 나이 설정 (디자인 897-4862) — UserData.childAge 연결됨
 //
 
 import SwiftUI

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/HomeSelectionView.swift
@@ -81,18 +81,6 @@ struct HomeSelectionView: View {
     }
 }
 
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
-}
-
 #if DEBUG
 #Preview {
     NavigationStack {

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/NotificationTimeSettingView.swift
@@ -2,7 +2,7 @@
 //  NotificationTimeSettingView.swift
 //  LivingStory-iOS
 //
-//  알림 시간 설정 (디자인 897-4898) — 현재 UI만, 값 더미
+//  알림 시간 설정 (디자인 897-4898) — UserData + ReadingNotificationScheduler 연결됨
 //
 
 import SwiftUI
@@ -55,11 +55,11 @@ struct NotificationTimeSettingView: View {
                     HStack(spacing: 8) {
                         Image(systemName: "exclamationmark.circle.fill")
                             .foregroundStyle(.yellow60)
-                        Text("알림이 꺼져 있어요. 설정 > 나루 > 알림에서 켜주세요")
+                        Text(StringLiterals.Setting.notificationDeniedNotice)
                             .font(.labelRegular)
                             .foregroundStyle(.white.opacity(0.8))
                         Spacer()
-                        Button("설정") {
+                        Button(StringLiterals.Setting.openSettings) {
                             if let url = URL(string: UIApplication.openSettingsURLString) {
                                 UIApplication.shared.open(url)
                             }

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Settings/SettingsView.swift
@@ -2,7 +2,8 @@
 //  SettingsView.swift
 //  LivingStory-iOS
 //
-//  설정 메인 (디자인 897-4792) — 현재 UI만, 값 더미
+//  설정 메인 (디자인 897-4792)
+//  나이·알림 시간·버전은 실제 값 연결됨. 집 이름만 더미(PO-107 머지 후 연결 예정).
 //
 
 import SwiftUI
@@ -15,8 +16,11 @@ struct SettingsView: View {
     @State private var childAge: String = ""
     @State private var notificationTime: String = ""
 
+    // TODO: 집 선택 실제 연결 — PO-107(HomeDataProviding 멀티캐스트 구독) 머지 후 진행
     private let homeName = "서울 집"
-    private let appVersion = "1.0.0"
+
+    /// Info.plist(CFBundleShortVersionString) 조회 — 빌드 설정 MARKETING_VERSION과 항상 일치
+    private let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-"
 
     /// 오후 09:30 형식
     private static let timeFormatter: DateFormatter = {
@@ -84,7 +88,7 @@ struct SettingsView: View {
 
     /// 진입/복귀 시 저장값을 화면 상태로 재로드
     private func reload() {
-        childAge = "\(UserData.childAge)살"
+        childAge = "\(UserData.childAge)\(StringLiterals.Setting.ageUnit)"
         notificationTime = Self.timeFormatter.string(from: UserData.notificationTime)
     }
 

--- a/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
+++ b/LivingStory-iOS/LivingStory-iOS/Presentation/Screens/Statistics/StatisticsView.swift
@@ -232,18 +232,6 @@ private struct StatBookThumbnail: View {
     }
 }
 
-// MARK: - Color Helper
-
-private extension Color {
-    init(hex: UInt) {
-        self.init(
-            red: Double((hex >> 16) & 0xFF) / 255,
-            green: Double((hex >> 8) & 0xFF) / 255,
-            blue: Double(hex & 0xFF) / 255
-        )
-    }
-}
-
 // MARK: - Preview
 
 #if DEBUG


### PR DESCRIPTION
Closes #126

## 📝 Summary
설정 화면 계열(PO-86/PO-89)에 남아있던 하드코딩을 정리했습니다. **(A) 화면엔 값이 보이지만 실제로는 더미인 것**과 **(B) `StringLiterals`/`ColorLiterals` 체계를 만들어두고 인라인으로 박아둔 것** 두 갈래입니다. PO-86 심볼 토큰화와 같은 결입니다.

## 🔨 What

### 데이터 연결
- **`ReadingViewModel`**: `private static let childAge = 6` 상수 제거 → `UserData.childAge` 참조 (질문 생성 2곳)
  - `ScannerViewController`는 이미 `UserData.childAge`를 쓰고 있어 **두 경로가 갈라져 있던 것**을 통일. 설정에서 나이를 바꿔도 독서 플로우는 항상 6세 기준으로 질문을 받던 문제 해소
- **`SettingsView`**: 앱 버전 `"1.0.0"` 하드코딩 → `Bundle.main`의 `CFBundleShortVersionString` 조회
  - ⚠️ `MARKETING_VERSION`이 `1.0`이라 **표기가 `1.0.0` → `1.0`으로 바뀝니다.** 실제 번들 값을 그대로 읽은 결과이며, 디자이너 확인 예정

### 리터럴 토큰화
- **`NotificationTimeSettingView`**: 인라인 한글 2개 → `StringLiterals.Setting.notificationDeniedNotice` / `.openSettings`
- **나이 단위 통일**: 목록의 `"살"` → `Setting.ageUnit`(`"세"`). 목록 "6살" ↔ 상세 "만 6세" 표기 불일치 해소
- **중복 `Color(hex:)` 제거**: `ColorLiterals`에 정본이 있는데도 7개 파일이 각자 `private extension`으로 재정의하던 것 제거 (`ReadingView`는 `fillTertiary` 토큰만 남기고 init만 제거)
  - 호출부 71곳은 무수정 — 정본 시그니처가 `alpha` 기본값을 가져 호환
- 헤더 주석의 stale 문구(`— 현재 UI만, 값 더미`)를 실제 연결 상태에 맞게 갱신

**총 12파일 / +15 −92**

## 🚫 이번 PR에서 제외한 것
**집(Home) 선택 실제 연결은 제외했습니다.** PO-107(#125)이 `HomeDataProviding`을 단일 클로저 → `addObserver` 멀티캐스트 구독으로 바꾸는 중이라, 지금 연결하면 설정 화면이 홈 화면의 구독을 덮어쓰는 버그가 납니다. 게다가 PO-107이 "`make()`는 앱 전역 1회 호출(AppDelegate 소유)"로 정리하는 만큼, 설정의 집 선택은 그 위에 올리는 게 맞습니다.

→ **PO-107 머지 후 별도 이슈로 진행하겠습니다.** `SettingsView`에 TODO로 명시해뒀습니다.

## 👀 Review Notes
- **PO-106(#121)과 `ReadingViewModel` 154·199행이 겹칩니다.** 본 PR을 먼저 머지하고, #121에서 `aiService.generateQuestions(for: book, age: UserData.childAge)`로 합치는 방향으로 정리하겠습니다.
- `Color(hex:)` 확장 제거가 호출부 71곳에 영향을 주는 변경이라 이 부분 위주로 봐주시면 좋겠습니다.

## ✅ 확인
- [x] 빌드 확인
